### PR TITLE
[Ready for review] Remove unreachable code and refactor

### DIFF
--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -152,10 +152,6 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
                 .ok_or_else(|| StdError::generic_err("cannot find `contract_addr` attribute"))?
                 .value;
 
-            if ACCOUNTS().has(deps.storage, deps.api.addr_validate(&owner)?) {
-                return Err(ContractError::AccountAlreadyExists {});
-            }
-
             ACCOUNTS().save(
                 deps.storage,
                 deps.api.addr_validate(&owner)?,

--- a/contracts/warp-controller/src/error.rs
+++ b/contracts/warp-controller/src/error.rs
@@ -32,9 +32,6 @@ pub enum ContractError {
     #[error("Account does not exist")]
     AccountDoesNotExist {},
 
-    #[error("Account already exists")]
-    AccountAlreadyExists {},
-
     #[error("Account cannot create an account")]
     AccountCannotCreateAccount {},
 

--- a/contracts/warp-controller/src/execute/account.rs
+++ b/contracts/warp-controller/src/execute/account.rs
@@ -11,15 +11,17 @@ pub fn create_account(
 ) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
 
-    let item = ACCOUNTS()
+    // sender is a warp account, warp account cannot be the owner of another warp account
+    if ACCOUNTS()
         .idx
         .account
-        .item(deps.storage, info.sender.clone());
-
-    if item?.is_some() {
+        .item(deps.storage, info.sender.clone())?
+        .is_some()
+    {
         return Err(ContractError::AccountCannotCreateAccount {});
     }
 
+    // sender already owns a warp account, return the existing warp account and skip creating another one
     if ACCOUNTS().has(deps.storage, info.sender.clone()) {
         let account = ACCOUNTS().load(deps.storage, info.sender)?;
         return Ok(Response::new()

--- a/contracts/warp-controller/src/tests/execute/account/test_create_account.rs
+++ b/contracts/warp-controller/src/tests/execute/account/test_create_account.rs
@@ -25,7 +25,8 @@ fn test_create_account_success() {
     .unwrap();
 
     let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
-    let reply_res = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
+    let reply_res =
+        mock_account_creation_reply(&mut deps, env.clone(), info.clone(), Uint64::new(0));
 
     assert_eq!(
         create_account_res.unwrap(),
@@ -52,10 +53,10 @@ fn test_create_account_success() {
         reply_res.unwrap(),
         Response::new()
             .add_attribute("action", "save_account")
-            .add_attribute("owner", "terra1vladvladvladvladvladvladvladvladvl1000")
+            .add_attribute("owner", "vlad")
             .add_attribute(
                 "account_address",
-                "terra1vladvladvladvladvladvladvladvladvl2000"
+                "terra1vladvladvladvladvladvladvladvladvl1000"
             )
     )
 }
@@ -79,7 +80,8 @@ fn test_create_account_exists() {
     .unwrap();
 
     let _create_account_res_first = create_account(deps.as_mut(), env.clone(), info.clone());
-    let reply_res_first = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
+    let reply_res_first =
+        mock_account_creation_reply(&mut deps, env.clone(), info.clone(), Uint64::new(0));
 
     let reply_res_first_clone = reply_res_first.unwrap().clone();
     let attr_owner = reply_res_first_clone
@@ -94,7 +96,7 @@ fn test_create_account_exists() {
         .find(|attr| attr.key == "account_address")
         .ok_or_else(|| StdError::generic_err("cannot find `account_address` attribute"))
         .unwrap();
-    let info = mock_info(attr_owner.value.as_str(), &vec![coin(100, "uluna")]);
+
     let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
 
     assert_eq!(
@@ -125,7 +127,8 @@ fn test_create_account_by_account() {
     .unwrap();
 
     let _create_account_res_first = create_account(deps.as_mut(), env.clone(), info.clone());
-    let reply_res_first = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
+    let reply_res_first =
+        mock_account_creation_reply(&mut deps, env.clone(), info.clone(), Uint64::new(0));
 
     // Get address of warp account just created and assign it as the sender of next create_account call
     let reply_res_first_clone = reply_res_first.unwrap().clone();
@@ -139,6 +142,7 @@ fn test_create_account_by_account() {
         attr_warp_account_address.value.as_str(),
         &vec![coin(100, "uluna")],
     );
+
     let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
 
     assert_eq!(

--- a/contracts/warp-controller/src/tests/execute/account/test_create_account.rs
+++ b/contracts/warp-controller/src/tests/execute/account/test_create_account.rs
@@ -1,4 +1,5 @@
-use crate::tests::helpers::{create_warp_account, instantiate_warp};
+use crate::execute::account::create_account;
+use crate::tests::helpers::{instantiate_warp, mock_account_creation_reply};
 use crate::ContractError;
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{
@@ -23,8 +24,8 @@ fn test_create_account_success() {
     )
     .unwrap();
 
-    let (create_account_res, reply_res) =
-        create_warp_account(&mut deps, env.clone(), info.clone(), Uint64::new(0));
+    let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
+    let reply_res = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
 
     assert_eq!(
         create_account_res.unwrap(),
@@ -77,36 +78,32 @@ fn test_create_account_exists() {
     )
     .unwrap();
 
-    let (_create_account_res_first, _reply_res_first) =
-        create_warp_account(&mut deps, env.clone(), info.clone(), Uint64::new(0));
-    let (create_account_res, reply_res) =
-        create_warp_account(&mut deps, env.clone(), info.clone(), Uint64::new(0));
+    let _create_account_res_first = create_account(deps.as_mut(), env.clone(), info.clone());
+    let reply_res_first = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
+
+    let reply_res_first_clone = reply_res_first.unwrap().clone();
+    let attr_owner = reply_res_first_clone
+        .attributes
+        .iter()
+        .find(|attr| attr.key == "owner")
+        .ok_or_else(|| StdError::generic_err("cannot find `owner` attribute"))
+        .unwrap();
+    let attr_warp_account_address = reply_res_first_clone
+        .attributes
+        .iter()
+        .find(|attr| attr.key == "account_address")
+        .ok_or_else(|| StdError::generic_err("cannot find `account_address` attribute"))
+        .unwrap();
+    let info = mock_info(attr_owner.value.as_str(), &vec![coin(100, "uluna")]);
+    let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
 
     assert_eq!(
         create_account_res.unwrap(),
         Response::new()
             .add_attribute("action", "create_account")
-            .add_submessage(SubMsg {
-                id: 0,
-                msg: CosmosMsg::Wasm(WasmMsg::Instantiate {
-                    admin: None,
-                    code_id: 0,
-                    msg: to_binary(&warp_protocol::account::InstantiateMsg {
-                        owner: info.sender.to_string(),
-                    })
-                    .unwrap(),
-                    funds: vec![],
-                    label: info.sender.to_string(),
-                }),
-                gas_limit: None,
-                reply_on: ReplyOn::Always,
-            })
+            .add_attribute("owner", attr_owner.value.as_str())
+            .add_attribute("account_address", attr_warp_account_address.value.as_str())
     );
-
-    assert_eq!(
-        reply_res.unwrap_err(),
-        ContractError::AccountAlreadyExists {}
-    )
 }
 
 #[test]
@@ -127,8 +124,8 @@ fn test_create_account_by_account() {
     )
     .unwrap();
 
-    let (_create_account_res_first, reply_res_first) =
-        create_warp_account(&mut deps, env.clone(), info.clone(), Uint64::new(0));
+    let _create_account_res_first = create_account(deps.as_mut(), env.clone(), info.clone());
+    let reply_res_first = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
 
     // Get address of warp account just created and assign it as the sender of next create_account call
     let reply_res_first_clone = reply_res_first.unwrap().clone();
@@ -142,8 +139,7 @@ fn test_create_account_by_account() {
         attr_warp_account_address.value.as_str(),
         &vec![coin(100, "uluna")],
     );
-    let (create_account_res, _reply_res) =
-        create_warp_account(&mut deps, env.clone(), info.clone(), Uint64::new(0));
+    let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
 
     assert_eq!(
         create_account_res.unwrap_err(),

--- a/contracts/warp-controller/src/tests/execute/account/test_create_account.rs
+++ b/contracts/warp-controller/src/tests/execute/account/test_create_account.rs
@@ -6,11 +6,13 @@ use cosmwasm_std::{
     coin, to_binary, CosmosMsg, ReplyOn, Response, StdError, SubMsg, Uint128, Uint64, WasmMsg,
 };
 
+const MOCK_SENDER_ADDRESS: &str = "vlad";
+
 #[test]
 fn test_create_account_success() {
     let mut deps = mock_dependencies();
     let env = mock_env();
-    let info = mock_info("vlad", &vec![coin(100, "uluna")]);
+    let info = mock_info(MOCK_SENDER_ADDRESS, &vec![coin(100, "uluna")]);
 
     let _instantiate_res = instantiate_warp(
         deps.as_mut(),
@@ -53,7 +55,7 @@ fn test_create_account_success() {
         reply_res.unwrap(),
         Response::new()
             .add_attribute("action", "save_account")
-            .add_attribute("owner", "vlad")
+            .add_attribute("owner", info.sender)
             .add_attribute(
                 "account_address",
                 "terra1vladvladvladvladvladvladvladvladvl1000"
@@ -65,7 +67,7 @@ fn test_create_account_success() {
 fn test_create_account_exists() {
     let mut deps = mock_dependencies();
     let env = mock_env();
-    let info = mock_info("vlad", &vec![coin(100, "uluna")]);
+    let info = mock_info(MOCK_SENDER_ADDRESS, &vec![coin(100, "uluna")]);
 
     let _instantiate_res = instantiate_warp(
         deps.as_mut(),
@@ -84,12 +86,6 @@ fn test_create_account_exists() {
         mock_account_creation_reply(&mut deps, env.clone(), info.clone(), Uint64::new(0));
 
     let reply_res_first_clone = reply_res_first.unwrap().clone();
-    let attr_owner = reply_res_first_clone
-        .attributes
-        .iter()
-        .find(|attr| attr.key == "owner")
-        .ok_or_else(|| StdError::generic_err("cannot find `owner` attribute"))
-        .unwrap();
     let attr_warp_account_address = reply_res_first_clone
         .attributes
         .iter()
@@ -103,7 +99,7 @@ fn test_create_account_exists() {
         create_account_res.unwrap(),
         Response::new()
             .add_attribute("action", "create_account")
-            .add_attribute("owner", attr_owner.value.as_str())
+            .add_attribute("owner", info.sender)
             .add_attribute("account_address", attr_warp_account_address.value.as_str())
     );
 }
@@ -112,7 +108,7 @@ fn test_create_account_exists() {
 fn test_create_account_by_account() {
     let mut deps = mock_dependencies();
     let env = mock_env();
-    let info = mock_info("vlad", &vec![coin(100, "uluna")]);
+    let info = mock_info(MOCK_SENDER_ADDRESS, &vec![coin(100, "uluna")]);
 
     let _instantiate_res = instantiate_warp(
         deps.as_mut(),

--- a/contracts/warp-controller/src/tests/helpers.rs
+++ b/contracts/warp-controller/src/tests/helpers.rs
@@ -1,5 +1,4 @@
 use crate::contract::{instantiate, reply};
-use crate::execute::account::create_account;
 use crate::ContractError;
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
 use cosmwasm_std::{
@@ -30,17 +29,11 @@ pub fn instantiate_warp(
     return instantiate(deps, env.clone(), info.clone(), instantiate_msg.clone());
 }
 
-pub fn create_warp_account(
+pub fn mock_account_creation_reply(
     deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
     env: Env,
-    info: MessageInfo,
     account_id: Uint64,
-) -> (
-    Result<Response, ContractError>,
-    Result<Response, ContractError>,
-) {
-    let create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
-
+) -> Result<Response, ContractError> {
     let reply_msg = Reply {
         id: 0,
         result: SubMsgResult::Ok(SubMsgResponse {
@@ -65,7 +58,5 @@ pub fn create_warp_account(
         }),
     };
 
-    let reply_res = reply(deps.as_mut(), env, reply_msg);
-
-    return (create_account_res, reply_res);
+    return reply(deps.as_mut(), env, reply_msg);
 }

--- a/contracts/warp-controller/src/tests/helpers.rs
+++ b/contracts/warp-controller/src/tests/helpers.rs
@@ -32,6 +32,7 @@ pub fn instantiate_warp(
 pub fn mock_account_creation_reply(
     deps: &mut OwnedDeps<MockStorage, MockApi, MockQuerier>,
     env: Env,
+    info: MessageInfo,
     account_id: Uint64,
 ) -> Result<Response, ContractError> {
     let reply_msg = Reply {
@@ -39,18 +40,13 @@ pub fn mock_account_creation_reply(
         result: SubMsgResult::Ok(SubMsgResponse {
             events: vec![Event::new("wasm").add_attributes(vec![
                 Attribute::new("action", "instantiate"),
-                Attribute::new(
-                    "owner",
-                    format!(
-                        "terra1vladvladvladvladvladvladvladvladvl{}",
-                        account_id + Uint64::new(1000)
-                    ),
-                ),
+                Attribute::new("owner", info.sender),
+                // contract_addr needs to be mocked since it's generated in warp-account contract's instantiate fn
                 Attribute::new(
                     "contract_addr",
                     format!(
                         "terra1vladvladvladvladvladvladvladvladvl{}",
-                        account_id + Uint64::new(2000)
+                        account_id + Uint64::new(1000)
                     ),
                 ),
             ])],

--- a/contracts/warp-controller/src/tests/query/account/test_query_account.rs
+++ b/contracts/warp-controller/src/tests/query/account/test_query_account.rs
@@ -6,8 +6,9 @@ use cosmwasm_std::{
 use warp_protocol::controller::account::{Account, AccountResponse, QueryAccountMsg};
 
 use crate::{
+    execute::account::create_account,
     query::account::query_account,
-    tests::helpers::{create_warp_account, instantiate_warp},
+    tests::helpers::{instantiate_warp, mock_account_creation_reply},
 };
 
 #[test]
@@ -28,8 +29,8 @@ fn test_query_account_successful() {
     )
     .unwrap();
 
-    let (_create_account_res, reply_res) =
-        create_warp_account(&mut deps, env.clone(), info.clone(), Uint64::new(0));
+    let _create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
+    let reply_res = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
 
     // Get address of warp account just created and query it in query_account
     let reply_res_first_clone = reply_res.unwrap().clone();

--- a/contracts/warp-controller/src/tests/query/account/test_query_account.rs
+++ b/contracts/warp-controller/src/tests/query/account/test_query_account.rs
@@ -11,11 +11,13 @@ use crate::{
     tests::helpers::{instantiate_warp, mock_account_creation_reply},
 };
 
+const MOCK_SENDER_ADDRESS: &str = "vlad";
+
 #[test]
 fn test_query_account_successful() {
     let mut deps = mock_dependencies();
     let env = mock_env();
-    let info = mock_info("vlad", &vec![coin(100, "uluna")]);
+    let info = mock_info(MOCK_SENDER_ADDRESS, &vec![coin(100, "uluna")]);
 
     let _instantiate_res = instantiate_warp(
         deps.as_mut(),
@@ -35,12 +37,6 @@ fn test_query_account_successful() {
 
     // Get address of warp account just created and query it in query_account
     let reply_res_first_clone = reply_res.unwrap().clone();
-    let attr_owner = reply_res_first_clone
-        .attributes
-        .iter()
-        .find(|attr| attr.key == "owner")
-        .ok_or_else(|| StdError::generic_err("cannot find `owner` attribute"))
-        .unwrap();
     let attr_warp_account_address = reply_res_first_clone
         .attributes
         .iter()
@@ -52,7 +48,7 @@ fn test_query_account_successful() {
         deps.as_ref(),
         env,
         QueryAccountMsg {
-            owner: info.sender.into_string(),
+            owner: info.sender.clone().into_string(),
         },
     );
 
@@ -60,7 +56,7 @@ fn test_query_account_successful() {
         query_account_res.unwrap(),
         AccountResponse {
             account: Account {
-                owner: deps.api.addr_validate(attr_owner.value.as_str()).unwrap(),
+                owner: info.sender,
                 account: deps
                     .api
                     .addr_validate(attr_warp_account_address.value.as_str())
@@ -74,7 +70,7 @@ fn test_query_account_successful() {
 fn test_query_account_does_not_exist() {
     let mut deps = mock_dependencies();
     let env = mock_env();
-    let info = mock_info("vlad", &vec![coin(100, "uluna")]);
+    let info = mock_info(MOCK_SENDER_ADDRESS, &vec![coin(100, "uluna")]);
 
     let _instantiate_res = instantiate_warp(
         deps.as_mut(),

--- a/contracts/warp-controller/src/tests/query/account/test_query_account.rs
+++ b/contracts/warp-controller/src/tests/query/account/test_query_account.rs
@@ -30,7 +30,8 @@ fn test_query_account_successful() {
     .unwrap();
 
     let _create_account_res = create_account(deps.as_mut(), env.clone(), info.clone());
-    let reply_res = mock_account_creation_reply(&mut deps, env.clone(), Uint64::new(0));
+    let reply_res =
+        mock_account_creation_reply(&mut deps, env.clone(), info.clone(), Uint64::new(0));
 
     // Get address of warp account just created and query it in query_account
     let reply_res_first_clone = reply_res.unwrap().clone();
@@ -51,7 +52,7 @@ fn test_query_account_successful() {
         deps.as_ref(),
         env,
         QueryAccountMsg {
-            owner: attr_owner.value.clone(),
+            owner: info.sender.into_string(),
         },
     );
 


### PR DESCRIPTION
**What this PR does**
1. delete unreachable `AccountAlreadyExists` error in [issue 5](https://github.com/terra-money/warp-contracts/issues/5).
2. refactor helper to avoid coupling `create_account` and `account_creation_reply` together, since sometimes we return early in `create_account` and won't hit reply at all.
3. avoid mocking owner in `account_creation_reply` since we can get it from `info.sender`, I think it's better to only mock what's unknown (like warp account contract address).

**How does it work**

**Test plan**
Pass existing unit test.