### PR TITLE
support env variables in NumValue

### DIFF
--- a/contracts/warp-controller/src/util/condition.rs
+++ b/contracts/warp-controller/src/util/condition.rs
@@ -82,7 +82,9 @@ pub fn resolve_num_value_int(
         NumValue::Expr(expr) => resolve_num_expr_int(deps, env, expr, vars),
         NumValue::Ref(expr) => resolve_ref_int(deps, env, expr, vars),
         NumValue::Fn(expr) => resolve_num_fn_int(deps, env, expr, vars),
-        NumValue::Env(_expr) => Err(ContractError::ConditionError { msg: "Int resolve Env.".to_string() }),
+        NumValue::Env(_expr) => Err(ContractError::ConditionError {
+            msg: "Int resolve Env.".to_string(),
+        }),
     }
 }
 
@@ -314,7 +316,9 @@ pub fn resolve_num_value_decimal(
         NumValue::Expr(expr) => resolve_num_expr_decimal(deps, env, expr, vars),
         NumValue::Ref(expr) => resolve_ref_decimal(deps, env, expr, vars),
         NumValue::Fn(expr) => resolve_num_fn_decimal(deps, env, expr, vars),
-        NumValue::Env(_expr) => Err(ContractError::ConditionError { msg: "Decimal resolve Env.".to_string() }),
+        NumValue::Env(_expr) => Err(ContractError::ConditionError {
+            msg: "Decimal resolve Env.".to_string(),
+        }),
     }
 }
 

--- a/contracts/warp-controller/src/util/condition.rs
+++ b/contracts/warp-controller/src/util/condition.rs
@@ -82,7 +82,7 @@ pub fn resolve_num_value_int(
         NumValue::Expr(expr) => resolve_num_expr_int(deps, env, expr, vars),
         NumValue::Ref(expr) => resolve_ref_int(deps, env, expr, vars),
         NumValue::Fn(expr) => resolve_num_fn_int(deps, env, expr, vars),
-        NumValue::Env(expr) => resolve_num_env_int(deps, env, expr, vars),
+        NumValue::Env(_expr) => Err(ContractError::ConditionError { msg: "Int resolve Env.".to_string() }),
     }
 }
 
@@ -132,18 +132,6 @@ fn resolve_num_fn_int(
                     msg: "Int negation error.".to_string(),
                 })?)
         }
-    }
-}
-
-fn resolve_num_env_int(
-    _deps: Deps,
-    env: Env,
-    expr: NumEnvValue,
-    _vars: &Vec<Variable>,
-) -> Result<i128, ContractError> {
-    match expr {
-        NumEnvValue::Time => Ok(env.block.time.seconds().into()),
-        NumEnvValue::BlockHeight => Ok(env.block.height.into()),
     }
 }
 
@@ -326,7 +314,7 @@ pub fn resolve_num_value_decimal(
         NumValue::Expr(expr) => resolve_num_expr_decimal(deps, env, expr, vars),
         NumValue::Ref(expr) => resolve_ref_decimal(deps, env, expr, vars),
         NumValue::Fn(expr) => resolve_num_fn_decimal(deps, env, expr, vars),
-        NumValue::Env(expr) => resolve_num_env_decimal(deps, env, expr, vars),
+        NumValue::Env(_expr) => Err(ContractError::ConditionError { msg: "Decimal resolve Env.".to_string() }),
     }
 }
 
@@ -375,18 +363,6 @@ fn resolve_num_fn_decimal(
         DecimalFnOp::Floor => Ok(right.floor()),
         DecimalFnOp::Sqrt => Ok(right.sqrt()),
         DecimalFnOp::Ceil => Ok(right.ceil()),
-    }
-}
-
-fn resolve_num_env_decimal(
-    _deps: Deps,
-    env: Env,
-    expr: NumEnvValue,
-    _vars: &Vec<Variable>,
-) -> Result<Decimal256, ContractError> {
-    match expr {
-        NumEnvValue::Time => Ok(Decimal256::new(env.block.time.seconds().into())),
-        NumEnvValue::BlockHeight => Ok(Decimal256::new(env.block.height.into())),
     }
 }
 

--- a/contracts/warp-controller/src/util/condition.rs
+++ b/contracts/warp-controller/src/util/condition.rs
@@ -285,7 +285,7 @@ pub fn resolve_num_env_uint(
     _deps: Deps,
     env: Env,
     expr: NumEnvValue,
-    _vars: &Vec<Variable>,
+    _vars: &[Variable],
 ) -> Result<Uint256, ContractError> {
     match expr {
         NumEnvValue::Time => Ok(env.block.time.seconds().into()),

--- a/packages/warp-protocol/src/controller/condition.rs
+++ b/packages/warp-protocol/src/controller/condition.rs
@@ -41,6 +41,13 @@ pub enum NumValue<T, ExprOp, FnOp> {
     Expr(NumExprValue<T, ExprOp, FnOp>),
     Ref(String),
     Fn(NumFnValue<T, ExprOp, FnOp>),
+    Env(NumEnvValue),
+}
+
+#[cw_serde]
+pub enum NumEnvValue {
+    Time,
+    BlockHeight,
 }
 
 #[cw_serde]


### PR DESCRIPTION
This will add the possibility to access time and block_height variables in NumExpressions.


```rust
        let result = await context.sdk.createJob(context.accountAddress, {
          condition: {
            expr: {
              uint: {
                left: {
                  // access current_time when executing
                  env: 'time',
                },
                op: 'gt',
                right: {
                  ref: 'next_execution'
                }
              }
            },
          },
          recurring: true,
          requeue_on_evict: true,
          vars: [
            {
              static: {
                kind: 'uint',
                name: 'next_execution',
                value: '1',
                update_fn: {
                  on_error: {
                    uint: {
                      expr: {
                        left: {
                          // try again in 1 h
                          simple: 1 * 60 * 60,
                        },
                        op: 'add',
                        right: {
                          // access current time to calculate the next_execution when the execution failed
                          env: 'time',
                        },
                      },
                    },
                  },
                  on_success: {
                    uint: {
                      expr: {
                        left: {
                          // daily
                          simple: 24 * 60 * 60,
                        },
                        op: 'add',
                        right: {
                          // access current time to calculate the next_execution when the execution successful
                          env: 'time',
                        },
                      },
                    },
                  },
                },
              },
            },
          ],
          msgs: [
            {
              wasm: {
                execute: {
                  contract_addr: context.hub,
                  funds: [],
                  msg: base64encode({ harvest: {} }),
                },
              },
            },
          ],
          name: 'eris-harvest',
          reward: '10000',
        });
```