### PR TITLE
Fix/use quotes for variable storage

### DIFF
--- a/contracts/warp-controller/src/tests/test.rs
+++ b/contracts/warp-controller/src/tests/test.rs
@@ -1,5 +1,3 @@
-use cosmwasm_std::{to_vec, Binary, QueryRequest, StdError, WasmQuery};
-
 #[test]
 fn lol() {
     let v = "\"32000\"";

--- a/contracts/warp-controller/src/tests/util/test_vars.rs
+++ b/contracts/warp-controller/src/tests/util/test_vars.rs
@@ -1,3 +1,10 @@
+use warp_protocol::controller::{
+    condition::{Condition, Expr, GenExpr, NumOp, NumValue},
+    variable::{StaticVariable, Variable, VariableKind},
+};
+
+use crate::util::variable::all_vector_vars_present;
+
 #[test]
 fn test_vars() {
     let test_msg = "{\"execute\":{\"test\":\"$WARPVAR.test\"}}".to_string();
@@ -25,4 +32,24 @@ fn test_vars() {
     // String::insert_str(&mut test_msg, injected_idx, injected_json.as_str());
 
     println!("{}", test_msg);
+}
+
+#[test]
+fn test_all_vector_vars_present() {
+    let condition = Condition::Expr(Box::new(Expr::Uint(GenExpr {
+        left: NumValue::Env(warp_protocol::controller::condition::NumEnvValue::Time),
+        op: NumOp::Gt,
+        right: NumValue::Ref("$warp.variable.next_execution".to_string()),
+    })));
+
+    let cond_string = serde_json_wasm::to_string(&condition).unwrap();
+
+    let var = Variable::Static(StaticVariable {
+        kind: VariableKind::Uint,
+        name: "next_execution".to_string(),
+        value: "1".to_string(),
+        update_fn: None,
+    });
+
+    assert_eq!(all_vector_vars_present(&vec![var], cond_string), true);
 }

--- a/contracts/warp-controller/src/util/variable.rs
+++ b/contracts/warp-controller/src/util/variable.rs
@@ -6,8 +6,9 @@ use crate::util::condition::{
 use crate::ContractError;
 use cosmwasm_std::{CosmosMsg, Deps, Env};
 
+use warp_protocol::controller::condition::{Condition, Expr, GenExpr, NumExprOp, NumOp, NumValue};
 use warp_protocol::controller::job::{ExternalInput, JobStatus};
-use warp_protocol::controller::variable::{UpdateFnValue, Variable, VariableKind};
+use warp_protocol::controller::variable::{StaticVariable, UpdateFnValue, Variable, VariableKind};
 
 pub fn hydrate_vars(
     deps: Deps,
@@ -183,8 +184,10 @@ pub fn apply_var_fn(
                                             msg: "Static Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = format!(
+                                        "\"{}\"",
+                                        resolve_num_value_uint(deps, env.clone(), nv, &vars)?
+                                    );
                                 }
                                 UpdateFnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -201,9 +204,10 @@ pub fn apply_var_fn(
                                             msg: "Static Decimal function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value =
+                                    v.value = format!(
+                                        "\"{}\"",
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string();
+                                    );
                                 }
                                 UpdateFnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -244,8 +248,10 @@ pub fn apply_var_fn(
                                             msg: "Static Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = format!(
+                                        "\"{}\"",
+                                        resolve_num_value_uint(deps, env.clone(), nv, &vars)?
+                                    );
                                 }
                                 UpdateFnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -262,9 +268,10 @@ pub fn apply_var_fn(
                                             msg: "Static Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value =
+                                    v.value = format!(
+                                        "\"{}\"",
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string();
+                                    );
                                 }
                                 UpdateFnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -323,10 +330,10 @@ pub fn apply_var_fn(
                                             msg: "External Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -345,10 +352,10 @@ pub fn apply_var_fn(
                                             msg: "External Decimal function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -396,10 +403,10 @@ pub fn apply_var_fn(
                                             msg: "External Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -418,10 +425,10 @@ pub fn apply_var_fn(
                                             msg: "External Decimal function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -487,10 +494,10 @@ pub fn apply_var_fn(
                                             msg: "Query Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -509,10 +516,10 @@ pub fn apply_var_fn(
                                             msg: "Query Decimal function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -559,10 +566,10 @@ pub fn apply_var_fn(
                                             msg: "Query Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -581,10 +588,10 @@ pub fn apply_var_fn(
                                             msg: "Query Decimal function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = Some(
+                                    v.value = Some(format!(
+                                        "\"{}\"",
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string(),
-                                    )
+                                    ))
                                 }
                                 UpdateFnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {

--- a/contracts/warp-controller/src/util/variable.rs
+++ b/contracts/warp-controller/src/util/variable.rs
@@ -6,9 +6,8 @@ use crate::util::condition::{
 use crate::ContractError;
 use cosmwasm_std::{CosmosMsg, Deps, Env};
 
-use warp_protocol::controller::condition::{Condition, Expr, GenExpr, NumExprOp, NumOp, NumValue};
 use warp_protocol::controller::job::{ExternalInput, JobStatus};
-use warp_protocol::controller::variable::{StaticVariable, UpdateFnValue, Variable, VariableKind};
+use warp_protocol::controller::variable::{UpdateFnValue, Variable, VariableKind};
 
 pub fn hydrate_vars(
     deps: Deps,


### PR DESCRIPTION
When executing a job after the initial creation it updates the value of the var without the quotes.

see:
https://terrasco.pe/testnet/address/terra1d3jc2v4empz03w096f68hqyrp6ml6a264e7wyp0ta83cxtdlrmksumskvz/smart/ewogICJxdWVyeV9qb2IiOiB7CiAgICAgICJpZCI6ICIyMiIKICB9Cn0=

          "value": "1676239489",

which will be cut to 67623948

.

This variable parsing will also be needed to be implemented in warp-sdk.

Example for resolveNumValue (@simke9445 )
![image](https://user-images.githubusercontent.com/9350951/218284093-19c711e0-8c33-43c9-ad7f-43737e258e32.png)
