### PR TITLE
support using cron expressions for timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base16ct"
@@ -56,6 +71,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,16 +89,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "iana-time-zone",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -341,6 +396,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +618,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +655,15 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json-codec-wasm"
@@ -556,6 +688,43 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -681,6 +850,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sec1"
@@ -840,6 +1015,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +1068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1104,7 @@ name = "warp-controller"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "chrono",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -954,6 +1145,91 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/contracts/warp-controller/Cargo.toml
+++ b/contracts/warp-controller/Cargo.toml
@@ -44,6 +44,7 @@ schemars = "0.8"
 thiserror = "1"
 serde-json-wasm = "0.4.1"
 json-codec-wasm = "0.1.0"
+chrono = { version = "=0.4.23", default-features = false, features = ["clock"]}
 
 [dev-dependencies]
 cw-multi-test = "0.16.0"

--- a/contracts/warp-controller/src/cron/crontab.rs
+++ b/contracts/warp-controller/src/cron/crontab.rs
@@ -1,0 +1,623 @@
+use chrono::Datelike;
+
+use super::error::CrontabError;
+use super::parsing::{parse_cron, ScheduleComponents};
+use super::times::{adv_day, adv_hour, adv_minute, adv_month};
+use super::tm::{weekday_to_tm_wday, Tm};
+
+/// Represents a crontab schedule.
+#[derive(Clone)]
+pub struct Crontab {
+    /// The components parsed from a crontab schedule.
+    pub schedule: ScheduleComponents,
+}
+
+impl Crontab {
+    /// Parse a crontab schedule into a Crontab instance.
+    pub fn parse(crontab_schedule: &str) -> Result<Crontab, CrontabError> {
+        let schedule = parse_cron(crontab_schedule)?;
+        Ok(Crontab { schedule: schedule })
+    }
+
+    // TODO/FIXME: Optional API is a bit strange. Get rid of the Option wrapper.
+    /// Given a start time, calculate the next time this event will take place.
+    /// It will always return a time after the time provided, even if the time
+    /// provided happens to be a time specified by the cron schedule.
+    ///
+    /// Usage:
+    ///
+    /// ```
+    /// extern crate crontab;
+    /// extern crate time;
+    ///
+    /// let ct = crontab::Crontab::parse("0 0 * * *").ok().unwrap(); // Every midnight.
+    /// let next = ct.find_event_after(&time::now()).unwrap();
+    /// println!("Next time is: {:?}", next);
+    /// ```
+    pub fn find_event_after(&self, start_time_s: u64) -> u64 {
+        calculate_next_event(&self.schedule, &Tm::from_timestamp(start_time_s))
+            .unwrap()
+            .to_unix()
+    }
+}
+
+// TODO: Stop testing this. Test the Crontab method instead.
+pub(crate) fn calculate_next_event(times: &ScheduleComponents, time: &Tm) -> Option<Tm> {
+    let mut next_time = time.clone();
+
+    // Minute-resolution. We're always going to round up to the next minute.
+    next_time.tm_sec = 0;
+    adv_minute(&mut next_time);
+
+    loop {
+        match try_month(times, &mut next_time) {
+            DateTimeMatch::Missed => continue,    // Retry
+            DateTimeMatch::ContinueMatching => {} // Continue
+            DateTimeMatch::AnswerFound(upcoming) => return Some(upcoming),
+        }
+
+        match try_day(times, &mut next_time) {
+            DateTimeMatch::Missed => continue,    // Retry
+            DateTimeMatch::ContinueMatching => {} // Continue
+            DateTimeMatch::AnswerFound(upcoming) => return Some(upcoming),
+        }
+
+        match try_hour(times, &mut next_time) {
+            DateTimeMatch::Missed => continue,    // Retry
+            DateTimeMatch::ContinueMatching => {} // Continue
+            DateTimeMatch::AnswerFound(upcoming) => return Some(upcoming),
+        }
+
+        match try_minute(times, &mut next_time) {
+            DateTimeMatch::Missed => continue, // Retry
+            DateTimeMatch::ContinueMatching => {
+                // Does not happen
+                return None;
+            }
+            DateTimeMatch::AnswerFound(upcoming) => return Some(upcoming),
+        }
+    }
+}
+
+enum DateTimeMatch {
+    Missed,
+    ContinueMatching,
+    AnswerFound(Tm),
+}
+
+fn try_month(times: &ScheduleComponents, time: &mut Tm) -> DateTimeMatch {
+    // Tm month range is [0, 11]
+    // Cron months are [1, 12]
+    let test_month = (time.tm_mon + 1) as u32;
+
+    match times.months.binary_search(&test_month) {
+        Ok(_) => {
+            // Precise month... must keep matching
+            DateTimeMatch::ContinueMatching
+        }
+        Err(pos) => {
+            if let Some(month) = times.months.get(pos) {
+                // Next month. We're done.
+                let mut use_time = time.clone();
+                use_time.tm_mon = month - 1;
+                // Tm day range is [1, 31]
+                use_time.tm_mday = times.days.get(0).unwrap().clone();
+                // Tm hour range is [0, 23]
+                use_time.tm_hour = times.hours.get(0).unwrap().clone();
+                // Tm minute range is [0, 59]
+                use_time.tm_min = times.minutes.get(0).unwrap().clone();
+                use_time.tm_sec = 0; // Second resolution
+
+                DateTimeMatch::AnswerFound(use_time)
+            } else {
+                // Skipped beyond. Pop to last unit and use next value.
+                time.tm_year = time.tm_year + 1;
+                // Tm month range is [0, 11], Cron months are [1, 12]
+                time.tm_mon = times.months.get(0).unwrap().clone() - 1;
+                // Tm day range is [1, 31]
+                time.tm_mday = times.days.get(0).unwrap().clone();
+                // Tm hour range is [0, 23]
+                time.tm_hour = times.hours.get(0).unwrap().clone();
+                // Tm minute range is [0, 59]
+                time.tm_min = times.minutes.get(0).unwrap().clone();
+                time.tm_sec = 0; // Second resolution
+
+                DateTimeMatch::Missed
+            }
+        }
+    }
+}
+
+fn try_day(times: &ScheduleComponents, time: &mut Tm) -> DateTimeMatch {
+    match times.days.binary_search(&(time.tm_mday as u32)) {
+        Ok(_) => {
+            let weekday = weekday_to_tm_wday(time.to_datetime().weekday());
+
+            match times.weekdays.binary_search(&weekday) {
+                Ok(_) => {
+                    // Precise day and matching weekday... must keep matching
+                    DateTimeMatch::ContinueMatching
+                }
+                Err(_) => {
+                    // only move to the next day instead of next month
+                    time.tm_hour = 0; // Reset hour
+                    time.tm_min = 0; // Reset minute
+                    time.tm_sec = 0; // Reset second
+                    adv_day(time);
+                    DateTimeMatch::Missed
+                }
+            }
+        }
+        Err(pos) => {
+            if let Some(day) = times.days.get(pos) {
+                // Next day. We're done.
+                let mut use_time = time.clone();
+                // Tm day range is [1, 31]
+                use_time.tm_mday = day.clone();
+                // Tm hour range is [0, 23]
+                use_time.tm_hour = times.hours.get(0).unwrap().clone();
+                // Tm minute range is [0, 59]
+                use_time.tm_min = times.minutes.get(0).unwrap().clone();
+                use_time.tm_sec = 0; // Second resolution
+
+                DateTimeMatch::AnswerFound(use_time)
+            } else {
+                time.tm_mday = 1; // Reset day (1-indexed)
+                time.tm_hour = 0; // Reset hour
+                time.tm_min = 0; // Reset minute
+                time.tm_sec = 0; // Reset second
+                adv_month(time);
+                DateTimeMatch::Missed
+            }
+        }
+    }
+}
+
+fn try_hour(times: &ScheduleComponents, time: &mut Tm) -> DateTimeMatch {
+    match times.hours.binary_search(&(time.tm_hour as u32)) {
+        Ok(_) => {
+            // Precise month... must keep matching
+            DateTimeMatch::ContinueMatching
+        }
+        Err(pos) => {
+            if let Some(hour) = times.hours.get(pos) {
+                // Next hour. We're done.
+                let mut use_time = time.clone();
+                // Tm hour range is [0, 23]
+                use_time.tm_hour = hour.clone();
+                // Tm minute range is [0, 59]
+                use_time.tm_min = times.minutes.get(0).unwrap().clone();
+                use_time.tm_sec = 0; // Second resolution
+
+                DateTimeMatch::AnswerFound(use_time)
+            } else {
+                time.tm_hour = 0; // Reset hour
+                time.tm_min = 0; // Reset minute
+                time.tm_sec = 0; // Reset second
+                adv_day(time);
+                DateTimeMatch::Missed
+            }
+        }
+    }
+}
+
+fn try_minute(times: &ScheduleComponents, time: &mut Tm) -> DateTimeMatch {
+    match times.minutes.binary_search(&(time.tm_min as u32)) {
+        Ok(_) => {
+            // DONE
+            let mut use_time = time.clone();
+            //use_time.tm_min = minute.clone() as i32;
+            use_time.tm_sec = 0; // Second resolution
+            DateTimeMatch::AnswerFound(use_time)
+        }
+        Err(pos) => {
+            if let Some(minute) = times.minutes.get(pos) {
+                // Next minute. We're done.
+                let mut use_time = time.clone();
+                // Tm minute range is [0, 59]
+                use_time.tm_min = minute.clone();
+                use_time.tm_sec = 0; // Second resolution
+
+                DateTimeMatch::AnswerFound(use_time)
+            } else {
+                time.tm_min = 0; // Reset minute
+                time.tm_sec = 0; // Reset second
+                adv_hour(time);
+                DateTimeMatch::Missed
+            }
+        }
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crontab::Crontab;
+//     use expectest::prelude::*;
+//     use test_helpers::get_tm;
+//     use test_helpers::normal;
+//     use time::{at_utc, Timespec};
+
+//     fn parse_times(schedule: &str) -> ScheduleComponents {
+//         let crontab = Crontab::parse(schedule).ok().unwrap();
+//         crontab.schedule
+//     }
+
+//     #[test]
+//     fn every_minute() {
+//         let times = parse_times("* * * * *"); // every minute
+
+//         // Advances the minute
+//         let tm = get_tm(2001, 1, 1, 12, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 1, 1, 12, 1, 0)));
+
+//         // Again
+//         let tm = get_tm(2001, 1, 1, 12, 30, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 1, 1, 12, 31, 0)));
+
+//         // Advances the hour
+//         let tm = get_tm(2001, 1, 1, 12, 59, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 1, 1, 13, 0, 0)));
+
+//         // Advances the day
+//         let tm = get_tm(2001, 1, 1, 23, 59, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 1, 2, 0, 0, 0)));
+
+//         // Advances the month
+//         let tm = get_tm(2001, 1, 31, 23, 59, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 2, 1, 0, 0, 0)));
+
+//         // Seconds get rounded up to the next minute
+//         let tm = get_tm(2001, 1, 1, 12, 0, 1);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 1, 1, 12, 1, 0)));
+//     }
+
+//     #[test]
+//     fn every_fifteen_minutes() {
+//         let times = parse_times("*/15 * * * *");
+
+//         // Minute before :15 (2017-05-15 11:14)
+//         let tm = get_tm(2017, 5, 15, 11, 14, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 5, 15, 11, 15, 0)));
+
+//         // Minute after :15 (2017-05-15 11:16)
+//         let tm = get_tm(2017, 5, 15, 11, 16, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 5, 15, 11, 30, 0)));
+
+//         // Minute after :30 (2017-05-15 11:31)
+//         let tm = get_tm(2017, 5, 15, 11, 31, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 5, 15, 11, 45, 0)));
+
+//         // Minute before :00 (2017-10-15 23:59)
+//         let tm = get_tm(2017, 10, 15, 23, 59, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 10, 16, 0, 0, 0)));
+
+//         // Two minutes before New Year (2017-12-31 23:58)
+//         let tm = get_tm(2017, 12, 31, 23, 58, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2018, 1, 1, 0, 0, 0)));
+
+//         // Minute before New Year (2017-12-31 23:59)
+//         let tm = get_tm(2017, 12, 31, 23, 59, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2018, 1, 1, 0, 0, 0)));
+//     }
+
+//     #[test]
+//     fn precise_date_and_time() {
+//         let times = parse_times("0 0 1 10 *"); // 0:00 Oct 1st
+
+//         // Minute before
+//         let tm = get_tm(2017, 9, 30, 23, 59, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 10, 1, 0, 0, 0)));
+
+//         // Second before
+//         let tm = get_tm(2017, 9, 30, 23, 59, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 10, 1, 0, 0, 0)));
+
+//         // Month before
+//         let tm = get_tm(2017, 9, 1, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 10, 1, 0, 0, 0)));
+
+//         // Minute after ... must wait a year!
+//         let tm = get_tm(2017, 10, 1, 0, 1, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2018, 10, 1, 0, 0, 0)));
+
+//         // Month after... must wait 11 months!
+//         let tm = get_tm(2017, 11, 1, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2018, 10, 1, 0, 0, 0)));
+
+//         // Now with more nonzero time fields...
+//         // Oct 13 @ 22:45
+//         let times = parse_times("45 22 13 10 *");
+
+//         // Before (all time fields are nonzero)
+//         let tm = get_tm(2017, 7, 4, 10, 30, 1);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2017, 10, 13, 22, 45, 0)));
+
+//         // After (all time fields are nonzero)
+//         let tm = get_tm(2017, 11, 15, 10, 30, 15);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2018, 10, 13, 22, 45, 0)));
+//     }
+
+//     #[test]
+//     fn first_of_the_month() {
+//         // First of the month at 0:00.
+//         let times = parse_times("0 0 1 * *");
+
+//         // A minute late... advances the month.
+//         let tm = get_tm(2004, 1, 1, 0, 1, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2004, 2, 1, 0, 0, 0)));
+
+//         // A few hours late... advances the month.
+//         let tm = get_tm(2004, 1, 1, 12, 59, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2004, 2, 1, 0, 0, 0)));
+
+//         // Halfway through month advances the month.
+//         let tm = get_tm(2004, 1, 15, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2004, 2, 1, 0, 0, 0)));
+
+//         // Halfway through month at end of year advances the year.
+//         let tm = get_tm(2004, 12, 15, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2005, 1, 1, 0, 0, 0)));
+//     }
+
+//     #[test]
+//     fn every_hour_in_january_and_july() {
+//         // Every single hour in January and July.
+//         let times = parse_times("0 * * 1,7 *");
+
+//         // Last minute of December
+//         let tm = get_tm(2005, 12, 31, 23, 59, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2006, 1, 1, 0, 0, 0)));
+
+//         // First hour of January... advances to the next hour
+//         let tm = get_tm(2005, 1, 1, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2005, 1, 1, 1, 0, 0)));
+
+//         // Noon January 15th... advances to the next hour
+//         let tm = get_tm(2005, 1, 15, 12, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2005, 1, 15, 13, 0, 0)));
+
+//         // Last minute of January... advances to July.
+//         let tm = get_tm(2005, 1, 31, 23, 59, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2005, 7, 1, 0, 0, 0)));
+
+//         // First hour of July... advances to the next hour
+//         let tm = get_tm(2005, 7, 1, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2005, 7, 1, 1, 0, 0)));
+
+//         // Last hour of July... advances to next year's January
+//         let tm = get_tm(2005, 7, 31, 23, 59, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2006, 1, 1, 0, 0, 0)));
+//     }
+
+//     #[test]
+//     fn new_years() {
+//         // At the New Year's ball drop.
+//         let times = parse_times("0 0 1 1 *");
+
+//         // Last minute of December
+//         let tm = get_tm(2007, 12, 31, 23, 59, 59);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2008, 1, 1, 0, 0, 0)));
+
+//         // Minute zero of the new year... advances to next year
+//         let tm = get_tm(2007, 1, 1, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2008, 1, 1, 0, 0, 0)));
+
+//         // Minute five of the new year... advances to next year
+//         let tm = get_tm(2007, 1, 1, 0, 5, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2008, 1, 1, 0, 0, 0)));
+
+//         // Hour one of the new year... advances to next year
+//         let tm = get_tm(2007, 1, 1, 1, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2008, 1, 1, 0, 0, 0)));
+
+//         // Day two of the new year... advances to next year
+//         let tm = get_tm(2007, 1, 2, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2008, 1, 1, 0, 0, 0)));
+
+//         // July advances to the next year
+//         let tm = get_tm(2007, 7, 1, 0, 0, 0);
+//         let next = calculate_next_event(&times, &tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2008, 1, 1, 0, 0, 0)));
+//     }
+
+//     #[test]
+//     fn spot_check_fields_every_day() {
+//         // Every single day at midnight.
+//         let times = parse_times("0 0 * * *");
+
+//         // 2017-01-01 00:00 UTC, a non-leap year starting on a Sunday (tm_wday=0).
+//         let timespec = Timespec::new(1483228800, 0);
+//         let mut last = at_utc(timespec);
+//         let mut next = last.clone();
+//         let mut expected = last.clone();
+
+//         // First day of 2017. (tm_year=117)
+//         expect!(last.tm_year).to(be_equal_to(117));
+//         expect!(next.tm_mon).to(be_equal_to(0));
+//         expect!(last.tm_yday).to(be_equal_to(0));
+//         expect!(next.tm_mday).to(be_equal_to(1)); // 1-indexed
+//         expect!(last.tm_wday).to(be_equal_to(0)); // 2017 starts on a Sunday
+
+//         for _ in 0..365 {
+//             // We expect the next event to be the next day.
+//             adv_day(&mut expected);
+//             next = calculate_next_event(&times, &last).unwrap();
+
+//             // Check expectations.
+//             expect!(next.tm_year).to(be_equal_to(expected.tm_year));
+//             expect!(next.tm_mon).to(be_equal_to(expected.tm_mon));
+//             expect!(next.tm_mday).to(be_equal_to(expected.tm_mday));
+//             expect!(next.tm_yday).to(be_equal_to(expected.tm_yday));
+//             expect!(next.tm_wday).to(be_equal_to(expected.tm_wday));
+
+//             // Midnight
+//             expect!(next.tm_hour).to(be_equal_to(0));
+//             expect!(next.tm_min).to(be_equal_to(0));
+//             expect!(next.tm_sec).to(be_equal_to(0));
+
+//             adv_day(&mut last);
+//         }
+
+//         // First day of 2018. (tm_year=118)
+//         expect!(next.tm_year).to(be_equal_to(118));
+//         expect!(next.tm_mon).to(be_equal_to(0));
+//         expect!(next.tm_yday).to(be_equal_to(0));
+//         expect!(next.tm_mday).to(be_equal_to(1)); // 1-indexed
+//         expect!(next.tm_wday).to(be_equal_to(1)); // 2018 starts on a Monday
+
+//         // The next two years aren't leap years.
+//         for _ in 0..(365 * 2) {
+//             // We expect the next event to be the next day.
+//             adv_day(&mut expected);
+//             next = calculate_next_event(&times, &last).unwrap();
+
+//             // Check expectations.
+//             expect!(next.tm_year).to(be_equal_to(expected.tm_year));
+//             expect!(next.tm_mon).to(be_equal_to(expected.tm_mon));
+//             expect!(next.tm_mday).to(be_equal_to(expected.tm_mday));
+//             expect!(next.tm_yday).to(be_equal_to(expected.tm_yday));
+//             expect!(next.tm_wday).to(be_equal_to(expected.tm_wday));
+
+//             // Midnight
+//             expect!(next.tm_hour).to(be_equal_to(0));
+//             expect!(next.tm_min).to(be_equal_to(0));
+//             expect!(next.tm_sec).to(be_equal_to(0));
+
+//             adv_day(&mut last);
+//         }
+
+//         // First day of 2020.
+//         expect!(next.tm_year).to(be_equal_to(120));
+//         expect!(next.tm_mon).to(be_equal_to(0));
+//         expect!(next.tm_yday).to(be_equal_to(0));
+//         expect!(next.tm_mday).to(be_equal_to(1)); // 1-indexed
+//         expect!(next.tm_wday).to(be_equal_to(3)); // 2018 starts on a Wednesday
+
+//         // 2020 is a leap year
+//         for _ in 0..366 {
+//             // We expect the next event to be the next day.
+//             adv_day(&mut expected);
+//             next = calculate_next_event(&times, &last).unwrap();
+
+//             // Check expectations.
+//             expect!(next.tm_year).to(be_equal_to(expected.tm_year));
+//             expect!(next.tm_mon).to(be_equal_to(expected.tm_mon));
+//             expect!(next.tm_mday).to(be_equal_to(expected.tm_mday));
+//             expect!(next.tm_yday).to(be_equal_to(expected.tm_yday));
+//             expect!(next.tm_wday).to(be_equal_to(expected.tm_wday));
+
+//             // Midnight
+//             expect!(next.tm_hour).to(be_equal_to(0));
+//             expect!(next.tm_min).to(be_equal_to(0));
+//             expect!(next.tm_sec).to(be_equal_to(0));
+
+//             adv_day(&mut last);
+//         }
+
+//         // First day of 2021.
+//         expect!(next.tm_year).to(be_equal_to(121));
+//         expect!(next.tm_mon).to(be_equal_to(0));
+//         expect!(next.tm_yday).to(be_equal_to(0));
+//         expect!(next.tm_mday).to(be_equal_to(1)); // 1-indexed
+//         expect!(next.tm_wday).to(be_equal_to(5)); // 2018 starts on a Friday
+//     }
+
+//     #[test]
+//     fn crontab_find_event_after() {
+//         let crontab = Crontab::parse("* * * * *").ok().unwrap(); // every minute
+//         let tm = get_tm(2001, 1, 1, 12, 0, 0);
+//         let next = crontab.find_event_after(&tm).unwrap();
+//         expect!(normal(&next)).to(be_equal_to(get_tm(2001, 1, 1, 12, 1, 0)));
+//     }
+
+//     // TODO: inject a fake clock
+//     #[test]
+//     fn crontab_find_next_event() {
+//         // Should be within 60 seconds.
+//         let crontab = Crontab::parse("* * * * *").ok().unwrap(); // every minute
+//         let current = now();
+//         let next = crontab.find_next_event().unwrap();
+//         let delta = next - current;
+//         expect!(delta.num_seconds()).to(be_greater_or_equal_to(0));
+//         expect!(delta.num_seconds()).to(be_less_than(60));
+
+//         // Should be within 1 hour.
+//         let crontab = Crontab::parse("0 * * * *").ok().unwrap(); // every hour
+//         let current = now();
+//         let next = crontab.find_next_event().unwrap();
+//         let delta = next - current;
+//         expect!(delta.num_hours()).to(be_greater_or_equal_to(0));
+//         expect!(delta.num_hours()).to(be_less_than(1));
+
+//         // Should be within 24 hours.
+//         let crontab = Crontab::parse("0 0 * * *").ok().unwrap(); // every day
+//         let current = now();
+//         let next = crontab.find_next_event().unwrap();
+//         let delta = next - current;
+//         expect!(delta.num_hours()).to(be_greater_or_equal_to(0));
+//         expect!(delta.num_hours()).to(be_less_than(24));
+//     }
+
+//     // TODO: inject a fake clock
+//     #[test]
+//     fn crontab_find_next_event_utc() {
+//         // Should be within 60 seconds.
+//         let crontab = Crontab::parse("* * * * *").ok().unwrap(); // every minute
+//         let current = now();
+//         let next = crontab.find_next_event_utc().unwrap();
+//         let delta = next - current;
+//         expect!(delta.num_seconds()).to(be_greater_or_equal_to(0));
+//         expect!(delta.num_seconds()).to(be_less_than(60));
+
+//         // Should be within 1 hour.
+//         let crontab = Crontab::parse("0 * * * *").ok().unwrap(); // every hour
+//         let current = now();
+//         let next = crontab.find_next_event_utc().unwrap();
+//         let delta = next - current;
+//         expect!(delta.num_hours()).to(be_greater_or_equal_to(0));
+//         expect!(delta.num_hours()).to(be_less_than(1));
+
+//         // Should be within 24 hours.
+//         let crontab = Crontab::parse("0 0 * * *").ok().unwrap(); // every day
+//         let current = now();
+//         let next = crontab.find_next_event_utc().unwrap();
+//         let delta = next - current;
+//         expect!(delta.num_hours()).to(be_greater_or_equal_to(0));
+//         expect!(delta.num_hours()).to(be_less_than(24));
+//     }
+// }

--- a/contracts/warp-controller/src/cron/error.rs
+++ b/contracts/warp-controller/src/cron/error.rs
@@ -1,0 +1,24 @@
+use std::num::ParseIntError;
+use thiserror::Error;
+
+// TODO: These errors could use some improvement, but that would be breaking.
+/// A library error.
+
+#[derive(Error, Debug, PartialEq)]
+pub enum CrontabError {
+    /// Error parsing the crontab schedule.
+    #[error("Error parsing cron format: {0}")]
+    ErrCronFormat(String),
+
+    /// Error parsing an integer in a crontab schedule.
+    #[error("Error parsing int: {0}")]
+    ErrParseInt(#[from] ParseIntError),
+
+    /// Parse error. When one of the cron schedule fields is outside of the
+    /// permitted range.
+    #[error("One of the fields is outside the permitted range: {description}")]
+    FieldOutsideRange {
+        /// Description of the error.
+        description: String,
+    },
+}

--- a/contracts/warp-controller/src/cron/mod.rs
+++ b/contracts/warp-controller/src/cron/mod.rs
@@ -1,0 +1,29 @@
+//! Crontab.rs is a library for parsing cron schedule expressions.
+
+// #![deny(deprecated)]
+// #![deny(missing_docs)]
+// #![deny(unreachable_patterns)]
+// #![deny(unused_extern_crates)]
+// #![deny(unused_imports)]
+// #![deny(unused_qualifications)]
+
+// extern crate time;
+
+// #[cfg(test)]
+// #[macro_use(expect)]
+// extern crate expectest;
+
+// TODO: Get rid of these.
+#[cfg(test)]
+mod test_helpers;
+
+mod crontab;
+mod error;
+mod parsing;
+mod times;
+pub mod tm;
+
+// Exports
+pub use crontab::Crontab;
+pub use error::CrontabError;
+pub use parsing::ScheduleComponents;

--- a/contracts/warp-controller/src/cron/parsing.rs
+++ b/contracts/warp-controller/src/cron/parsing.rs
@@ -1,0 +1,335 @@
+#![allow(deprecated)]
+
+use super::error::CrontabError;
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
+/// The components of a crontab schedule.
+/// The values in each field are guaranteed to be both unique and ordered.
+#[derive(Clone, Debug, Default)]
+pub struct ScheduleComponents {
+    /// Minutes in the schedule.
+    /// Range [0,59] inclusive.
+    pub minutes: Vec<u32>,
+
+    /// Hours in the schedule.
+    /// Range [0,23] inclusive.
+    pub hours: Vec<u32>,
+
+    /// Days of the month in the schedule.
+    /// Range [1,31] inclusive.
+    pub days: Vec<u32>,
+
+    /// Months in the schedule.
+    /// Range [1,12] inclusive.
+    pub months: Vec<u32>,
+
+    /// Days of the week in the schedule.
+    /// Range [0,6] inclusive.
+    pub weekdays: Vec<u32>,
+}
+
+pub(crate) fn parse_cron(schedule: &str) -> Result<ScheduleComponents, CrontabError> {
+    let fields: Vec<&str> = schedule.trim().split_whitespace().collect();
+
+    if fields.len() != 5 {
+        return Err(CrontabError::ErrCronFormat(format!(
+            "Invalid format: {}",
+            schedule
+        )));
+    }
+
+    let minutes = parse_field(fields[0], 0, 59)?;
+    let hours = parse_field(fields[1], 0, 23)?;
+    let days = parse_field(fields[2], 1, 31)?;
+    let months = parse_field(fields[3], 1, 12)?;
+    let weekdays = parse_field(fields[4], 0, 6)?;
+
+    Ok(ScheduleComponents {
+        minutes: minutes,
+        hours: hours,
+        days: days,
+        months: months,
+        weekdays: weekdays,
+    })
+}
+
+fn parse_field(field: &str, field_min: u32, field_max: u32) -> Result<Vec<u32>, CrontabError> {
+    let mut components = HashSet::<u32>::new();
+
+    for part in field.split(",") {
+        let mut min = field_min;
+        let mut max = field_max;
+        let mut step = 1;
+
+        // stepped, eg. */2 or 1-45/3
+        let stepped: Vec<&str> = part.splitn(2, "/").collect();
+
+        // ranges, eg. 1-30
+        let range: Vec<&str> = stepped[0].splitn(2, "-").collect();
+
+        if stepped.len() == 2 {
+            step = stepped[1].parse::<u32>()?;
+        }
+
+        if range.len() == 2 {
+            min = range[0].parse::<u32>()?;
+            max = range[1].parse::<u32>()?;
+        }
+
+        if stepped.len() == 1 && range.len() == 1 && part != "*" {
+            min = part.parse::<u32>()?;
+            max = min;
+        }
+
+        if min < field_min {
+            return Err(CrontabError::FieldOutsideRange {
+                description: format!("Value {} is less than minimum: {}", min, field_min),
+            });
+        }
+
+        if max > field_max {
+            return Err(CrontabError::FieldOutsideRange {
+                description: format!("Value {} is greater than maximum: {}", max, field_max),
+            });
+        }
+
+        let values = (min..max + 1)
+            .filter(|i| i % step == 0)
+            .collect::<Vec<u32>>();
+
+        components.extend(values);
+    }
+
+    let mut components: Vec<u32> = Vec::from_iter(components.into_iter());
+    components.sort();
+
+    Ok(components)
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use expectest::prelude::*;
+
+//     #[test]
+//     fn parse_fields() {
+//         // Precise number of fields
+//         expect!(parse_cron("* * * * *")).to(be_ok());
+//         // Incorrect number of fields
+//         expect!(parse_cron("")).to(be_err());
+//         expect!(parse_cron("* * * *")).to(be_err());
+//         expect!(parse_cron("* * * * * *")).to(be_err());
+//     }
+
+//     #[test]
+//     fn parse_whitespace() {
+//         // Allowed whitespace
+//         expect!(parse_cron("  * * * * *  ")).to(be_ok());
+//         expect!(parse_cron("\n\t* * * * *\n\t")).to(be_ok());
+//         expect!(parse_cron("\n\t*\n\t*\n\t*\n\t*\n\t*\n\t")).to(be_ok());
+//         expect!(parse_cron("    *    *    *    *    *    ")).to(be_ok());
+//         expect!(parse_cron("\r\r*\r\n*\t\t*\t\t*\n  *\n\r")).to(be_ok());
+//     }
+
+//     #[test]
+//     fn wildcards() {
+//         let parsed = parse_cron("* * * * *").unwrap();
+
+//         expect!(parsed.minutes).to(be_equal_to((0..60).collect::<Vec<u32>>()));
+//         expect!(parsed.hours).to(be_equal_to((0..24).collect::<Vec<u32>>()));
+//         expect!(parsed.days).to(be_equal_to((1..32).collect::<Vec<u32>>()));
+//         expect!(parsed.months).to(be_equal_to((1..13).collect::<Vec<u32>>()));
+//         expect!(parsed.weekdays).to(be_equal_to((0..7).collect::<Vec<u32>>()));
+//     }
+
+//     #[test]
+//     fn ranges() {
+//         let parsed = parse_cron("0-5 20-23 1-5 1-6 0-6").unwrap();
+
+//         expect!(parsed.minutes).to(be_equal_to(vec![0, 1, 2, 3, 4, 5]));
+//         expect!(parsed.hours).to(be_equal_to(vec![20, 21, 22, 23]));
+//         expect!(parsed.days).to(be_equal_to(vec![1, 2, 3, 4, 5]));
+//         expect!(parsed.months).to(be_equal_to(vec![1, 2, 3, 4, 5, 6]));
+//         expect!(parsed.weekdays).to(be_equal_to(vec![0, 1, 2, 3, 4, 5, 6]));
+//     }
+
+//     #[test]
+//     fn step() {
+//         let parsed = parse_cron("*/15 */4 */10 */3 */2").unwrap();
+
+//         expect!(parsed.minutes).to(be_equal_to(vec![0, 15, 30, 45]));
+//         expect!(parsed.hours).to(be_equal_to(vec![0, 4, 8, 12, 16, 20]));
+//         expect!(parsed.days).to(be_equal_to(vec![10, 20, 30]));
+//         expect!(parsed.months).to(be_equal_to(vec![3, 6, 9, 12]));
+//         expect!(parsed.weekdays).to(be_equal_to(vec![0, 2, 4, 6]));
+//     }
+
+//     #[test]
+//     fn ranges_with_step() {
+//         let parsed = parse_cron("0-30/5 0-12/2 1-20/5 1-10/2 0-5/2").unwrap();
+
+//         assert_eq!(parsed.minutes, vec![0, 5, 10, 15, 20, 25, 30]);
+//         expect!(parsed.hours).to(be_equal_to(vec![0, 2, 4, 6, 8, 10, 12]));
+//         expect!(parsed.days).to(be_equal_to(vec![5, 10, 15, 20]));
+//         expect!(parsed.months).to(be_equal_to(vec![2, 4, 6, 8, 10]));
+//         expect!(parsed.weekdays).to(be_equal_to(vec![0, 2, 4]));
+//     }
+
+//     #[test]
+//     fn comma_separated() {
+//         let parsed = parse_cron("0,5,15 0,12 1,15 1,3,6,9,12 0,1,2,3,4").unwrap();
+
+//         expect!(parsed.minutes).to(be_equal_to(vec![0, 5, 15]));
+//         expect!(parsed.hours).to(be_equal_to(vec![0, 12]));
+//         expect!(parsed.days).to(be_equal_to(vec![1, 15]));
+//         expect!(parsed.months).to(be_equal_to(vec![1, 3, 6, 9, 12]));
+//         expect!(parsed.weekdays).to(be_equal_to(vec![0, 1, 2, 3, 4]));
+//     }
+
+//     #[test]
+//     fn exact_minutes() {
+//         let parsed = parse_cron("0 * * * *").unwrap();
+//         expect!(parsed.minutes).to(be_equal_to(vec![0]));
+
+//         let parsed = parse_cron("5,10,15 * * * *").unwrap();
+//         expect!(parsed.minutes).to(be_equal_to(vec![5, 10, 15]));
+
+//         let parsed = parse_cron("59 * * * *").unwrap();
+//         expect!(parsed.minutes).to(be_equal_to(vec![59]));
+//     }
+
+//     #[test]
+//     fn exact_hours() {
+//         let parsed = parse_cron("* 0 * * *").unwrap();
+//         expect!(parsed.hours).to(be_equal_to(vec![0]));
+
+//         let parsed = parse_cron("* 1,12,20 * * *").unwrap();
+//         expect!(parsed.hours).to(be_equal_to(vec![1, 12, 20]));
+
+//         let parsed = parse_cron("* 23 * * *").unwrap();
+//         expect!(parsed.hours).to(be_equal_to(vec![23]));
+//     }
+
+//     #[test]
+//     fn exact_days() {
+//         let parsed = parse_cron("* * 1 * *").unwrap();
+//         expect!(parsed.days).to(be_equal_to(vec![1]));
+
+//         let parsed = parse_cron("* * 1,10,20,30 * *").unwrap();
+//         expect!(parsed.days).to(be_equal_to(vec![1, 10, 20, 30]));
+
+//         let parsed = parse_cron("* * 31 * *").unwrap();
+//         expect!(parsed.days).to(be_equal_to(vec![31]));
+//     }
+
+//     #[test]
+//     fn exact_months() {
+//         let parsed = parse_cron("* * * 1 *").unwrap();
+//         expect!(parsed.months).to(be_equal_to(vec![1]));
+
+//         let parsed = parse_cron("* * * 1,5,7,10 *").unwrap();
+//         expect!(parsed.months).to(be_equal_to(vec![1, 5, 7, 10]));
+
+//         let parsed = parse_cron("* * * 12 *").unwrap();
+//         expect!(parsed.months).to(be_equal_to(vec![12]));
+//     }
+
+//     #[test]
+//     fn exact_weekdays() {
+//         let parsed = parse_cron("* * * * 0").unwrap();
+//         expect!(parsed.weekdays).to(be_equal_to(vec![0]));
+
+//         let parsed = parse_cron("* * * * 1,2").unwrap();
+//         expect!(parsed.weekdays).to(be_equal_to(vec![1, 2]));
+
+//         let parsed = parse_cron("* * * * 6").unwrap();
+//         expect!(parsed.weekdays).to(be_equal_to(vec![6]));
+//     }
+
+//     #[test]
+//     fn exact_values_outside_range() {
+//         // Minutes
+//         expect!(parse_cron("60 * * * *")).to(be_err());
+//         expect!(parse_cron("-1 * * * *")).to(be_err());
+//         // Hours
+//         expect!(parse_cron("* 24 * * *")).to(be_err());
+//         expect!(parse_cron("* -1 * * *")).to(be_err());
+//         // Days
+//         expect!(parse_cron("* * 0 * *")).to(be_err());
+//         expect!(parse_cron("* * 32 * *")).to(be_err());
+//         expect!(parse_cron("* * -1 * *")).to(be_err());
+//         // Months
+//         expect!(parse_cron("* * * 0 *")).to(be_err());
+//         expect!(parse_cron("* * * 13 *")).to(be_err());
+//         expect!(parse_cron("* * * -1 *")).to(be_err());
+//         // Weekdays
+//         expect!(parse_cron("* * * * 7")).to(be_err());
+//         expect!(parse_cron("* * * * -1")).to(be_err());
+//     }
+
+//     #[test]
+//     fn ranges_outside_range() {
+//         // Minutes
+//         expect!(parse_cron("0-60 * * * *")).to(be_err());
+//         expect!(parse_cron("-1-0 * * * *")).to(be_err());
+//         // Hours
+//         expect!(parse_cron("* 0-24 * * *")).to(be_err());
+//         expect!(parse_cron("* -1-10 * * *")).to(be_err());
+//         // Days
+//         expect!(parse_cron("* * 0-5 * *")).to(be_err());
+//         expect!(parse_cron("* * 10-32 * *")).to(be_err());
+//         expect!(parse_cron("* * -1-20 * *")).to(be_err());
+//         // Months
+//         expect!(parse_cron("* * * 0-5 *")).to(be_err());
+//         expect!(parse_cron("* * * 6-13 *")).to(be_err());
+//         expect!(parse_cron("* * * -1-12 *")).to(be_err());
+//         // Weekdays
+//         expect!(parse_cron("* * * * 5-7")).to(be_err());
+//         expect!(parse_cron("* * * * -1-5")).to(be_err());
+//     }
+
+//     #[test]
+//     fn values_deduped() {
+//         let parsed = parse_cron("1,1,1,1 * * * *").unwrap();
+//         expect!(parsed.minutes).to(be_equal_to(vec![1]));
+
+//         let parsed = parse_cron("1,1-3 * * * *").unwrap();
+//         expect!(parsed.minutes).to(be_equal_to(vec![1, 2, 3]));
+
+//         let parsed = parse_cron("* * * 1-4,2,4,*/2 *").unwrap();
+//         expect!(parsed.months).to(be_equal_to(vec![1, 2, 3, 4, 6, 8, 10, 12]));
+//     }
+
+//     #[test]
+//     fn values_in_order() {
+//         let parsed = parse_cron("4,3,1,2 * * * *").unwrap();
+//         expect!(parsed.minutes).to(be_equal_to(vec![1, 2, 3, 4]));
+//     }
+
+//     #[test]
+//     fn misc_parse_errors() {
+//         // Invalid values
+//         expect!(parse_cron("A B C D E")).to(be_err());
+//         expect!(parse_cron("*A *B *C *D *E")).to(be_err());
+
+//         // No numeric values
+//         expect!(parse_cron(", * * * *")).to(be_err());
+//         expect!(parse_cron(",,,, * * * *")).to(be_err());
+
+//         // No range
+//         expect!(parse_cron("- * * * *")).to(be_err());
+//         expect!(parse_cron(",- * * * *")).to(be_err());
+//         expect!(parse_cron("-,- * * * *")).to(be_err());
+//         expect!(parse_cron(",-,- * * * *")).to(be_err());
+//         expect!(parse_cron(",-,-, * * * *")).to(be_err());
+
+//         // Allowed whitespace, but incorrect number of fields
+//         expect!(parse_cron("   ")).to(be_err());
+//         expect!(parse_cron("  * * * *  ")).to(be_err());
+//         expect!(parse_cron("  * * * * * *  ")).to(be_err());
+//         expect!(parse_cron("\n\t")).to(be_err());
+//         expect!(parse_cron("\n\t* * * *\n\t")).to(be_err());
+//         expect!(parse_cron("\n\t* * * * * *\n\t")).to(be_err());
+//     }
+// }

--- a/contracts/warp-controller/src/cron/test_helpers.rs
+++ b/contracts/warp-controller/src/cron/test_helpers.rs
@@ -1,0 +1,53 @@
+// //! Functions used in the tests.
+// //! This module is only compiled for testing.
+
+// use expectest::prelude::*;
+// use time::Tm;
+
+// // TODO: Get rid of this. Not really necessary. Just hardcode dates and times.
+
+// /// Get a Tm from a date. Months and days are supplied 1-indexed, but
+// /// the Tm struct is inconsistently 0- and 1-indexed.
+// pub (crate) fn get_tm(year: i32,
+//                       month: i32,
+//                       day: i32,
+//                       hour: i32,
+//                       minute: i32,
+//                       second: i32) -> Tm {
+
+//   expect!(month).to(be_greater_or_equal_to(1));
+//   expect!(month).to(be_less_or_equal_to(12));
+//   expect!(day).to(be_greater_or_equal_to(1));
+//   expect!(day).to(be_less_or_equal_to(31));
+//   expect!(hour).to(be_greater_or_equal_to(0));
+//   expect!(hour).to(be_less_than(24));
+//   expect!(minute).to(be_greater_or_equal_to(0));
+//   expect!(minute).to(be_less_than(60));
+//   expect!(second).to(be_greater_or_equal_to(0));
+//   expect!(second).to(be_less_or_equal_to(60)); // leap seconds
+
+//   Tm {
+//     tm_sec: second,
+//     tm_min: minute,
+//     tm_hour: hour,
+//     tm_mday: day,
+//     tm_mon: month.saturating_sub(1), // zero indexed
+//     tm_year: year.saturating_sub(1900), // Years since 1900
+//     tm_wday: 0, // Incorrect, but don't care
+//     tm_yday: 0, // Incorrect, but don't care
+//     tm_isdst: 0,
+//     tm_utcoff: 0,
+//     tm_nsec: 0,
+//   }
+// }
+
+// /// Normalize a Tm to drop certain fields entirely.
+// pub (crate) fn normal(time: &Tm) -> Tm {
+//   let mut tm = time.clone();
+//   tm.tm_wday = 0;
+//   tm.tm_yday = 0;
+//   tm.tm_isdst = 0;
+//   tm.tm_utcoff = 0;
+//   tm.tm_nsec= 0;
+//   tm
+// }

--- a/contracts/warp-controller/src/cron/times.rs
+++ b/contracts/warp-controller/src/cron/times.rs
@@ -1,0 +1,238 @@
+use super::tm::Tm;
+
+/// Advance the year, but leave all other fields untouched.
+/// This can result in an invalid day-of-month, day-of-year, or day-of-week!
+pub(crate) fn adv_year(time: &mut Tm) {
+    time.tm_year += 1;
+}
+
+/// Advance the day, but leave the day (and hour, minute, second) untouched.
+/// This can result in an invalid day-of-month!
+pub(crate) fn adv_month(time: &mut Tm) {
+    time.tm_mon += 1;
+    if time.tm_mon > 11 {
+        time.tm_mon = 0;
+        adv_year(time);
+    }
+}
+
+/// Advance the day, but leave the hour, minute, and second untouched.
+pub(crate) fn adv_day(time: &mut Tm) {
+    time.tm_wday = (time.tm_wday + 1) % 7; // day of week
+    time.tm_mday += 1; // day of month
+
+    let is_leap_year = {
+        let year = time.tm_year + 1900;
+        if year % 400 == 0 || (year % 4 == 0 && year % 100 != 0) {
+            true
+        } else {
+            false
+        }
+    };
+
+    let days_in_year = if is_leap_year { 366 } else { 365 };
+
+    time.tm_yday = (time.tm_yday + 1) % days_in_year; // day of year
+
+    match time.tm_mon {
+        0 | 2 | 4 | 6 | 7 | 9 | 11 => {
+            if time.tm_mday > 31 {
+                time.tm_mday = 1;
+                adv_month(time);
+            }
+        }
+        3 | 5 | 8 | 10 => {
+            if time.tm_mday > 30 {
+                time.tm_mday = 1;
+                adv_month(time);
+            }
+        }
+        1 => {
+            let mdays = if is_leap_year { 29 } else { 28 };
+
+            if time.tm_mday > mdays {
+                time.tm_mday = 1;
+                adv_month(time);
+            }
+        }
+        _ => {} // bad user input
+    }
+}
+
+/// Advance the hour, but leave the minute and second untouched.
+pub(crate) fn adv_hour(time: &mut Tm) {
+    time.tm_hour += 1;
+    if time.tm_hour > 23 {
+        time.tm_hour = 0;
+        adv_day(time);
+    }
+}
+
+/// Advance the minute, but leave the second untouched.
+pub(crate) fn adv_minute(time: &mut Tm) {
+    time.tm_min += 1;
+    if time.tm_min > 59 {
+        time.tm_min = 0;
+        adv_hour(time);
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//   use super::*;
+//   use expectest::prelude::*;
+//   use test_helpers::get_tm;
+//   use test_helpers::normal;
+//   use time::{Timespec, at_utc};
+
+//   #[test]
+//   pub fn test_adv_year() {
+//     let mut tm = get_tm(2017, 10, 6, 12, 24, 0);
+//     adv_year(&mut tm);
+//     expect!(normal(&tm)).to(be_equal_to(get_tm(2018, 10, 6, 12, 24, 0)));
+//   }
+
+//   #[test]
+//   pub fn test_adv_month() {
+//     // January
+//     let mut tm = get_tm(2017, 1, 1, 12, 0, 0);
+//     adv_month(&mut tm);
+//     expect!(normal(&tm)).to(be_equal_to(get_tm(2017, 2, 1, 12, 0, 0)));
+
+//     // December
+//     let mut tm = get_tm(2017, 12, 1, 0, 0, 0);
+//     adv_month(&mut tm);
+//     expect!(normal(&tm)).to(be_equal_to(get_tm(2018, 1, 1, 0, 0, 0)));
+//   }
+
+//   #[test]
+//   pub fn test_adv_day_on_mday() {
+//     // 2017-01-01 00:00 UTC, a non-leap year starting on a Sunday (tm_wday=0).
+//     let timespec = Timespec::new(1483228800, 0);
+//     let mut tm = at_utc(timespec);
+
+//     // 2017 to 2019 are not leap years
+//     let days_in_months = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+//     // 2017 is (tm_year=117)
+//     for tm_year in 117 .. 120 {
+//       expect!(tm.tm_year).to(be_equal_to(tm_year));
+
+//       for days_in_month in days_in_months.iter() {
+//         let bound = days_in_month + 1; // 1-indexed
+//         for expected_day in 1..bound {
+//           expect!(tm.tm_mday).to(be_equal_to(expected_day));
+//           adv_day(&mut tm);
+//         }
+//       }
+//     }
+
+//     expect!(tm.tm_year).to(be_equal_to(120));
+
+//     // 2020 is a leap-year
+//     let days_in_months = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+//     for days_in_month in days_in_months.iter() {
+//       let bound = days_in_month + 1; // 1-indexed
+//       for expected_day in 1..bound {
+//         expect!(tm.tm_mday).to(be_equal_to(expected_day));
+//         adv_day(&mut tm);
+//       }
+//     }
+
+//     expect!(tm.tm_year).to(be_equal_to(121));
+//   }
+
+//   #[test]
+//   pub fn test_adv_day_on_wday() {
+//     // 2017-01-01 00:00 UTC, a non-leap year starting on a Sunday (tm_wday=0).
+//     let timespec = Timespec::new(1483228800, 0);
+//     let mut tm = at_utc(timespec);
+
+//     // First week.
+//     expect!(tm.tm_wday).to(be_equal_to(0));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(1));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(2));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(3));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(4));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(5));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(6));
+//     adv_day(&mut tm);
+//     expect!(tm.tm_wday).to(be_equal_to(0)); // Back to sunday!
+
+//     // Four more years...
+//     let mut expected = 0;
+//     for _ in 0 .. 1460 {
+//       expected = (expected + 1) % 7;
+//       adv_day(&mut tm);
+//       expect!(tm.tm_wday).to(be_equal_to(expected));
+//     }
+
+//     // Reset.
+//     let mut tm = at_utc(timespec);
+
+//     expect!(tm.tm_year).to(be_equal_to(117)); // 2017
+//     expect!(tm.tm_wday).to(be_equal_to(0)); // Starts on a Sunday
+
+//     // Entire year.
+//     for _ in 0 .. 365 {
+//       adv_day(&mut tm);
+//     }
+
+//     // Now it's 2018-01-01
+//     expect!(tm.tm_year).to(be_equal_to(118)); // 2018
+//     expect!(tm.tm_wday).to(be_equal_to(1)); // Starts on a Monday
+//   }
+
+//   #[test]
+//   pub fn test_adv_day_on_yday() {
+//     // 2017-01-01 00:00 UTC, a non-leap year starting on a Sunday (tm_wday=0).
+//     let timespec = Timespec::new(1483228800, 0);
+//     let mut tm = at_utc(timespec);
+
+//     // First day of 2017. (tm_year=117)
+//     expect!(tm.tm_year).to(be_equal_to(117));
+//     expect!(tm.tm_yday).to(be_equal_to(0));
+
+//     // 2017 passes...
+//     for expected_day in 0 .. 365 {
+//       expect!(tm.tm_year).to(be_equal_to(117)); // 2017
+//       expect!(tm.tm_yday).to(be_equal_to(expected_day));
+//       adv_day(&mut tm);
+//     }
+
+//     // First day of 2018.
+//     expect!(tm.tm_year).to(be_equal_to(118));
+//     expect!(tm.tm_yday).to(be_equal_to(0));
+
+//     // 2018 and 2019 pass... (Also not leap years.)
+//     for year in 118 .. 120 {
+//       for expected_day in 0 .. 365 {
+//         expect!(tm.tm_year).to(be_equal_to(year));
+//         expect!(tm.tm_yday).to(be_equal_to(expected_day));
+//         adv_day(&mut tm);
+//       }
+//     }
+
+//     // First day of 2020.
+//     expect!(tm.tm_year).to(be_equal_to(120));
+//     expect!(tm.tm_yday).to(be_equal_to(0));
+
+//     // This is a leap year!
+//     for expected_day in 0 .. 366 {
+//       expect!(tm.tm_year).to(be_equal_to(120));
+//       expect!(tm.tm_yday).to(be_equal_to(expected_day));
+//       adv_day(&mut tm);
+//     }
+
+//     // First day of 2021.
+//     expect!(tm.tm_year).to(be_equal_to(121));
+//     expect!(tm.tm_yday).to(be_equal_to(0));
+//   }
+// }

--- a/contracts/warp-controller/src/cron/tm.rs
+++ b/contracts/warp-controller/src/cron/tm.rs
@@ -1,0 +1,64 @@
+use chrono::{DateTime, Datelike, NaiveDateTime, TimeZone, Timelike, Utc, Weekday};
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct Tm {
+    pub tm_sec: u32,
+    pub tm_min: u32,
+    pub tm_hour: u32,
+    pub tm_mday: u32,
+    pub tm_mon: u32,
+    pub tm_year: i32,
+    pub tm_wday: u32,
+    pub tm_yday: u32,
+}
+
+impl Tm {
+    pub fn from_timestamp(time_s: u64) -> Tm {
+        let secs = time_s;
+
+        let initial_datetime: DateTime<Utc> = DateTime::from_utc(
+            NaiveDateTime::from_timestamp_opt(secs as i64, 0).unwrap(),
+            Utc,
+        );
+
+        Tm {
+            tm_sec: initial_datetime.second(),
+            tm_min: initial_datetime.minute(),
+            tm_hour: initial_datetime.hour(),
+            tm_mday: initial_datetime.day(),
+            tm_mon: initial_datetime.month(),
+            tm_year: initial_datetime.year(),
+            tm_wday: weekday_to_tm_wday(initial_datetime.weekday()),
+            tm_yday: initial_datetime.ordinal(),
+        }
+    }
+
+    pub fn to_datetime(&self) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(
+            self.tm_year,
+            self.tm_mon,
+            self.tm_mday,
+            self.tm_hour,
+            self.tm_min,
+            self.tm_sec,
+        )
+        .unwrap()
+    }
+
+    pub fn to_unix(&self) -> u64 {
+        self.to_datetime().timestamp() as u64
+    }
+}
+
+pub fn weekday_to_tm_wday(weekday: Weekday) -> u32 {
+    match weekday {
+        chrono::Weekday::Mon => 1,
+        chrono::Weekday::Tue => 2,
+        chrono::Weekday::Wed => 3,
+        chrono::Weekday::Thu => 4,
+        chrono::Weekday::Fri => 5,
+        chrono::Weekday::Sat => 6,
+        chrono::Weekday::Sun => 0,
+    }
+}

--- a/contracts/warp-controller/src/error.rs
+++ b/contracts/warp-controller/src/error.rs
@@ -1,3 +1,4 @@
+use crate::cron::CrontabError;
 use crate::ContractError::{CustomError, DecodeError, DeserializationError, SerializationError};
 use cosmwasm_std::{DivideByZeroError, OverflowError, StdError};
 use std::num::ParseIntError;
@@ -8,6 +9,9 @@ use thiserror::Error;
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
+
+    #[error("{0}")]
+    Crontab(#[from] CrontabError),
 
     #[error("Unauthorized")]
     Unauthorized {},

--- a/contracts/warp-controller/src/lib.rs
+++ b/contracts/warp-controller/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod cron;
 mod error;
 pub mod state;
 

--- a/contracts/warp-controller/src/tests/cron/mod.rs
+++ b/contracts/warp-controller/src/tests/cron/mod.rs
@@ -1,0 +1,1 @@
+pub mod schedule;

--- a/contracts/warp-controller/src/tests/cron/schedule.rs
+++ b/contracts/warp-controller/src/tests/cron/schedule.rs
@@ -1,0 +1,40 @@
+use crate::cron::Crontab;
+
+#[test]
+pub fn test_schedule_minute() {
+    // https://terrasco.pe/mainnet/blocks/3859156
+    // Monday, 20.2.2023, 08:14:59
+    let time = 1676880899;
+    let schedule = "* * * * *";
+    let result = get_next(schedule, time);
+
+    // one second is the next
+    assert_eq!(result, 1676880900);
+
+    let result = get_next(schedule, result);
+    assert_eq!(result, 1676880900 + 60);
+}
+
+#[test]
+pub fn test_schedule_monthly_weekday() {
+    // https://terrasco.pe/mainnet/blocks/3859156
+    // Monday, 20.2.2023, 08:14:59
+    let time = 1676880899;
+
+    // usually in crontab it would mean on day 1-7 of the month and also every monday.
+    // we adjusted crontab to be more sane to combine both requirements, this means it executes on the first monday each month
+    // if the other condition should be applied it is still possible in warp with multiple cron expressions and the expression-tree
+    let schedule = "0 5 1-7 * 1";
+    let result = get_next(schedule, time);
+
+    // Monday, March 6, 2023 5:00:00 AM
+    assert_eq!(result, 1678078800);
+
+    let result = get_next(schedule, result);
+    // Monday, April 3, 2023 5:00:00 AM
+    assert_eq!(result, 1680498000);
+}
+
+fn get_next(schedule: &str, time: u64) -> u64 {
+    Crontab::parse(schedule).unwrap().find_event_after(time)
+}

--- a/contracts/warp-controller/src/tests/mod.rs
+++ b/contracts/warp-controller/src/tests/mod.rs
@@ -1,3 +1,4 @@
+pub mod cron;
 mod execute;
 mod helpers;
 mod query;

--- a/contracts/warp-controller/src/util/condition.rs
+++ b/contracts/warp-controller/src/util/condition.rs
@@ -1,3 +1,4 @@
+use crate::cron::Crontab;
 use crate::util::path::resolve_path;
 use crate::util::variable::get_var;
 use crate::ContractError;
@@ -290,6 +291,9 @@ pub fn resolve_num_env_uint(
     match expr {
         NumEnvValue::Time => Ok(env.block.time.seconds().into()),
         NumEnvValue::BlockHeight => Ok(env.block.height.into()),
+        NumEnvValue::NextTimeFromCron(crontab_schedule) => Ok(Crontab::parse(&crontab_schedule)?
+            .find_event_after(env.block.time.seconds())
+            .into()),
     }
 }
 

--- a/packages/warp-protocol/src/controller/condition.rs
+++ b/packages/warp-protocol/src/controller/condition.rs
@@ -48,6 +48,7 @@ pub enum NumValue<T, ExprOp, FnOp> {
 pub enum NumEnvValue {
     Time,
     BlockHeight,
+    NextTimeFromCron(String),
 }
 
 #[cw_serde]


### PR DESCRIPTION
This pr will allow some very powerful schedules based on a cron timer. It is only a PoC and if interested I will also adjust the tests to run properly.

It only supports basic crons (with numbers) for performance / gas reasons.

It uses chrono (https://github.com/chronotope/chrono) to convert a unix timestamp to a datetime with components to start the search and convert the result back)

For the search structure the tm structure has been copied: https://docs.rs/mysql/14.0.0/mysql/time/struct.Tm.html

The implementation is based on https://crates.io/crates/crontab with adjustments for weekday support.
This is the major difference to normal cron, that weekdays are complimentary to all other options, which is a lot more sane in my opinion than in the normal implementation. It allows for powerful options like recurring jobs executing exactly first monday of a month (what we will need for our amp governance tune+redelegation)

There is this for blockchains optimized version: https://github.com/CronCats/Schedule
It is a bit more powerful, but not as lightweight as what could be enough for warp.

Usage is quite similar to the example in https://github.com/terra-money/warp-contracts/pull/15

```rust
        let result = await context.sdk.createJob(context.accountAddress, {
          condition: {
            expr: {
              uint: {
                left: {
                  // access current_time when executing
                  env: 'time',
                },
                op: 'gt',
                right: {
                  ref: 'next_execution'
                }
              }
            },
          },
          recurring: true,
          requeue_on_evict: true,
          vars: [
            {
              static: {
                kind: 'uint',
                name: 'next_execution',
                value: '1',
                update_fn: {
                  on_error: { ... }
                  on_success: {
                    uint: {
                      env: {
                        // execute 5:00 (0 5) on first - seventh day of a month (1-7), but only on monday (1)
                        // That means execute first monday of a month at 5:00
                        next_time_for_cron: '0 5 1-7 * 1'
                      }
                    },
                  },
                },
              },
            },
          ],
          msgs: [
            {
              wasm: {
                execute: {
                  contract_addr: context.hub,
                  funds: [],
                  msg: base64encode({ harvest: {} }),
                },
              },
            },
          ],
          name: 'eris-harvest',
          reward: '10000',
        });
```

