### PR TITLE
Add terminate_condition to job

### DIFF
--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -1,5 +1,6 @@
 use crate::error::map_contract_error;
 use crate::state::{ACCOUNTS, CONFIG, FINISHED_JOBS, PENDING_JOBS};
+use crate::util::condition::resolve_cond;
 use crate::util::variable::apply_var_fn;
 use crate::{execute, query, state::STATE, ContractError};
 use account::{GenericMsg, WithdrawAssetsMsg};
@@ -250,6 +251,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                     labels: job.labels,
                     status: new_status,
                     condition: job.condition,
+                    terminate_condition: job.terminate_condition,
                     msgs: job.msgs,
                     vars: job.vars,
                     recurring: job.recurring,
@@ -306,97 +308,141 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                         finished_job.vars,
                         finished_job.status.clone(),
                     )?;
-                    let new_job = PENDING_JOBS().update(
-                        deps.storage,
-                        state.current_job_id.u64(),
-                        |s| match s {
-                            None => Ok(Job {
-                                id: state.current_job_id,
-                                owner: finished_job.owner.clone(),
-                                last_update_time: Uint64::from(env.block.time.seconds()),
-                                name: finished_job.name.clone(),
-                                description: finished_job.description,
-                                labels: finished_job.labels,
-                                status: JobStatus::Pending,
-                                condition: finished_job.condition.clone(),
-                                vars: new_vars,
-                                requeue_on_evict: finished_job.requeue_on_evict,
-                                recurring: finished_job.recurring,
-                                msgs: finished_job.msgs.clone(),
-                                reward: finished_job.reward,
-                                assets_to_withdraw: finished_job.assets_to_withdraw,
-                            }),
-                            Some(_) => Err(ContractError::JobAlreadyExists {}),
-                        },
-                    )?;
 
-                    state.current_job_id = state.current_job_id.checked_add(Uint64::new(1))?;
-                    state.q = state.q.checked_add(Uint64::new(1))?;
+                    let should_terminate_job: bool;
+                    match finished_job.terminate_condition.clone() {
+                        Some(terminate_condition) => {
+                            let terminate_condition_resolution: Result<bool, ContractError> =
+                                resolve_cond(
+                                    deps.as_ref(),
+                                    env.clone(),
+                                    terminate_condition.clone(),
+                                    &new_vars,
+                                );
+                            match terminate_condition_resolution {
+                                Ok(true) => {
+                                    should_terminate_job = true;
+                                    new_job_attrs.push(Attribute::new("action", "recur_job"));
+                                    new_job_attrs.push(Attribute::new(
+                                        "creation_status",
+                                        "terminated_due_to_terminate_condition_resolves_to_true",
+                                    ));
+                                }
+                                Ok(false) => {
+                                    should_terminate_job = false;
+                                }
+                                Err(e) => {
+                                    should_terminate_job = true;
+                                    new_job_attrs.push(Attribute::new("action", "recur_job"));
+                                    new_job_attrs.push(Attribute::new(
+                                        "creation_status",
+                                        format!(
+                                            "terminated_due_to_terminate_condition_resolve_to_error. {}",
+                                            e.to_string()
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+                        None => {
+                            should_terminate_job = false;
+                        }
+                    }
 
-                    msgs.push(
-                        //send reward to controller
-                        WasmMsg::Execute {
-                            contract_addr: account.account.to_string(),
-                            msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg {
-                                msgs: vec![CosmosMsg::Bank(BankMsg::Send {
-                                    to_address: config.fee_collector.to_string(),
-                                    amount: vec![Coin::new((fee).u128(), "uluna")],
-                                })],
-                            }))?,
-                            funds: vec![],
-                        },
-                    );
+                    if !should_terminate_job {
+                        let new_job = PENDING_JOBS().update(
+                            deps.storage,
+                            state.current_job_id.u64(),
+                            |s| match s {
+                                None => Ok(Job {
+                                    id: state.current_job_id,
+                                    owner: finished_job.owner.clone(),
+                                    last_update_time: Uint64::from(env.block.time.seconds()),
+                                    name: finished_job.name.clone(),
+                                    description: finished_job.description,
+                                    labels: finished_job.labels,
+                                    status: JobStatus::Pending,
+                                    condition: finished_job.condition.clone(),
+                                    terminate_condition: finished_job.terminate_condition.clone(),
+                                    vars: new_vars,
+                                    requeue_on_evict: finished_job.requeue_on_evict,
+                                    recurring: finished_job.recurring,
+                                    msgs: finished_job.msgs.clone(),
+                                    reward: finished_job.reward,
+                                    assets_to_withdraw: finished_job.assets_to_withdraw,
+                                }),
+                                Some(_) => Err(ContractError::JobAlreadyExists {}),
+                            },
+                        )?;
 
-                    msgs.push(
-                        //send reward to controller
-                        WasmMsg::Execute {
-                            contract_addr: account.account.to_string(),
-                            msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg {
-                                msgs: vec![CosmosMsg::Bank(BankMsg::Send {
-                                    to_address: env.contract.address.to_string(),
-                                    amount: vec![Coin::new((new_job.reward).u128(), "uluna")],
-                                })],
-                            }))?,
-                            funds: vec![],
-                        },
-                    );
+                        state.current_job_id = state.current_job_id.checked_add(Uint64::new(1))?;
+                        state.q = state.q.checked_add(Uint64::new(1))?;
 
-                    msgs.push(
-                        //withdraw all assets that are listed
-                        WasmMsg::Execute {
-                            contract_addr: account.account.to_string(),
-                            msg: to_binary(&account::ExecuteMsg::WithdrawAssets(
-                                WithdrawAssetsMsg {
-                                    asset_infos: new_job.assets_to_withdraw,
-                                },
-                            ))?,
-                            funds: vec![],
-                        },
-                    );
+                        msgs.push(
+                            //send reward to controller
+                            WasmMsg::Execute {
+                                contract_addr: account.account.to_string(),
+                                msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg {
+                                    msgs: vec![CosmosMsg::Bank(BankMsg::Send {
+                                        to_address: config.fee_collector.to_string(),
+                                        amount: vec![Coin::new((fee).u128(), "uluna")],
+                                    })],
+                                }))?,
+                                funds: vec![],
+                            },
+                        );
 
-                    new_job_attrs.push(Attribute::new("action", "create_job"));
-                    new_job_attrs.push(Attribute::new("job_id", new_job.id));
-                    new_job_attrs.push(Attribute::new("job_owner", new_job.owner));
-                    new_job_attrs.push(Attribute::new("job_name", new_job.name));
-                    new_job_attrs.push(Attribute::new(
-                        "job_status",
-                        serde_json_wasm::to_string(&new_job.status)?,
-                    ));
-                    new_job_attrs.push(Attribute::new(
-                        "job_condition",
-                        serde_json_wasm::to_string(&new_job.condition)?,
-                    ));
-                    new_job_attrs.push(Attribute::new(
-                        "job_msgs",
-                        serde_json_wasm::to_string(&new_job.msgs)?,
-                    ));
-                    new_job_attrs.push(Attribute::new("job_reward", new_job.reward));
-                    new_job_attrs.push(Attribute::new("job_creation_fee", fee));
-                    new_job_attrs.push(Attribute::new(
-                        "job_last_updated_time",
-                        new_job.last_update_time,
-                    ));
-                    new_job_attrs.push(Attribute::new("sub_action", "recur_job"));
+                        msgs.push(
+                            //send reward to controller
+                            WasmMsg::Execute {
+                                contract_addr: account.account.to_string(),
+                                msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg {
+                                    msgs: vec![CosmosMsg::Bank(BankMsg::Send {
+                                        to_address: env.contract.address.to_string(),
+                                        amount: vec![Coin::new((new_job.reward).u128(), "uluna")],
+                                    })],
+                                }))?,
+                                funds: vec![],
+                            },
+                        );
+
+                        msgs.push(
+                            //withdraw all assets that are listed
+                            WasmMsg::Execute {
+                                contract_addr: account.account.to_string(),
+                                msg: to_binary(&account::ExecuteMsg::WithdrawAssets(
+                                    WithdrawAssetsMsg {
+                                        asset_infos: new_job.assets_to_withdraw,
+                                    },
+                                ))?,
+                                funds: vec![],
+                            },
+                        );
+
+                        new_job_attrs.push(Attribute::new("action", "create_job"));
+                        new_job_attrs.push(Attribute::new("job_id", new_job.id));
+                        new_job_attrs.push(Attribute::new("job_owner", new_job.owner));
+                        new_job_attrs.push(Attribute::new("job_name", new_job.name));
+                        new_job_attrs.push(Attribute::new(
+                            "job_status",
+                            serde_json_wasm::to_string(&new_job.status)?,
+                        ));
+                        new_job_attrs.push(Attribute::new(
+                            "job_condition",
+                            serde_json_wasm::to_string(&new_job.condition)?,
+                        ));
+                        new_job_attrs.push(Attribute::new(
+                            "job_msgs",
+                            serde_json_wasm::to_string(&new_job.msgs)?,
+                        ));
+                        new_job_attrs.push(Attribute::new("job_reward", new_job.reward));
+                        new_job_attrs.push(Attribute::new("job_creation_fee", fee));
+                        new_job_attrs.push(Attribute::new(
+                            "job_last_updated_time",
+                            new_job.last_update_time,
+                        ));
+                        new_job_attrs.push(Attribute::new("sub_action", "recur_job"));
+                    }
                 }
             }
 

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -89,6 +89,7 @@ pub fn create_job(
             name: data.name,
             status: JobStatus::Pending,
             condition: data.condition.clone(),
+            terminate_condition: data.terminate_condition,
             recurring: data.recurring,
             requeue_on_evict: data.requeue_on_evict,
             vars: data.vars,
@@ -180,6 +181,7 @@ pub fn delete_job(
             name: job.name,
             status: JobStatus::Cancelled,
             condition: job.condition,
+            terminate_condition: job.terminate_condition,
             msgs: job.msgs,
             vars: job.vars,
             recurring: job.recurring,
@@ -263,6 +265,7 @@ pub fn update_job(
             labels: data.labels.unwrap_or(job.labels),
             status: job.status,
             condition: job.condition,
+            terminate_condition: job.terminate_condition,
             msgs: job.msgs,
             vars: job.vars,
             recurring: job.recurring,
@@ -352,7 +355,7 @@ pub fn execute_job(
         data.external_inputs,
     )?;
 
-    let resolution = resolve_cond(deps.as_ref(), env, job.condition.clone(), &vars);
+    let resolution: Result<bool, ContractError> = resolve_cond(deps.as_ref(), env, job.condition.clone(), &vars);
 
     let mut attrs = vec![];
 
@@ -374,6 +377,7 @@ pub fn execute_job(
                 labels: job.labels,
                 status: JobStatus::Failed,
                 condition: job.condition,
+                terminate_condition: job.terminate_condition,
                 msgs: job.msgs,
                 vars,
                 recurring: job.recurring,
@@ -496,6 +500,7 @@ pub fn evict_job(
                     labels: job.labels,
                     status: JobStatus::Pending,
                     condition: job.condition,
+                    terminate_condition: job.terminate_condition,
                     msgs: job.msgs,
                     vars: job.vars,
                     recurring: job.recurring,
@@ -518,6 +523,7 @@ pub fn evict_job(
                     labels: job.labels,
                     status: JobStatus::Evicted,
                     condition: job.condition,
+                    terminate_condition: job.terminate_condition,
                     msgs: job.msgs,
                     vars: job.vars,
                     recurring: job.recurring,

--- a/contracts/warp-controller/src/tests/execute/job/test_create_job.rs
+++ b/contracts/warp-controller/src/tests/execute/job/test_create_job.rs
@@ -24,3 +24,6 @@ fn test_create_job_name_too_short() {}
 
 #[test]
 fn test_create_job_name_too_long() {}
+
+#[test]
+fn test_create_job_with_terminate_condition() {}

--- a/contracts/warp-controller/src/tests/execute/job/test_execute_job.rs
+++ b/contracts/warp-controller/src/tests/execute/job/test_execute_job.rs
@@ -20,3 +20,12 @@ fn test_execute_job_condition_improper_selector() {}
 
 #[test]
 fn test_execute_job_does_not_exist() {}
+
+#[test]
+fn test_execute_job_terminate_condition_resolves_to_true() {}
+
+#[test]
+fn test_execute_job_terminate_condition_resolves_to_false() {}
+
+#[test]
+fn test_execute_job_terminate_condition_resolves_to_error() {}

--- a/packages/controller/src/job.rs
+++ b/packages/controller/src/job.rs
@@ -31,7 +31,10 @@ pub struct Job {
     pub description: String,
     pub labels: Vec<String>,
     pub status: JobStatus,
+    // job becomes executable when condition resolves to true or fail to resolve
     pub condition: Condition,
+    // recurring job will be terminated when terminate_condition resolves to true or fail to resolve
+    pub terminate_condition: Option<Condition>,
     pub msgs: Vec<String>,
     pub vars: Vec<Variable>,
     pub recurring: bool,
@@ -61,6 +64,7 @@ pub struct CreateJobMsg {
     pub description: String,
     pub labels: Vec<String>,
     pub condition: Condition,
+    pub terminate_condition: Option<Condition>,
     pub msgs: Vec<String>,
     pub vars: Vec<Variable>,
     pub recurring: bool,


### PR DESCRIPTION
## Summary
Add a `terminate_condition` attribute to the job, it's optional and has same type as the `condition` which is used to decide if a job is executable, `terminate_condition` decides if a recurring job should be terminated (i.e. stop creating follow up job) when it executed successfully. 

If `terminate_condition` resolves to true or fail to resolve, recurring job will be terminated. Similar to `condition` resolves to true or fail to resolve, job will be executed.

## Test plan
- [ ]  Unit test
- [x]  Deploy the contract to localterra or testnet and verify if a DCA job can terminate by the terminate condition.