### PR TITLE
[Feature] Account atomic flow improvements

### DIFF
--- a/contracts/warp-account/src/contract.rs
+++ b/contracts/warp-account/src/contract.rs
@@ -2,6 +2,7 @@ use crate::state::CONFIG;
 use crate::ContractError;
 use account::{Config, ExecuteMsg, InstantiateMsg, QueryMsg, WithdrawAssetsMsg};
 use controller::account::{AssetInfo, Cw721ExecuteMsg};
+use controller::account::{Fund, FundTransferMsgs, TransferFromMsg, TransferNftMsg};
 use cosmwasm_std::{
     entry_point, to_binary, Addr, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
     Response, StdResult, Uint128, WasmMsg,
@@ -23,12 +24,59 @@ pub fn instantiate(
             warp_addr: info.sender,
         },
     )?;
+
+    let cw_funds_vec = match msg.funds.clone() {
+        None => {
+            vec![]
+        }
+        Some(funds) => funds,
+    };
+
+    let mut fund_msgs_vec: Vec<CosmosMsg> = vec![];
+
+    if !info.funds.is_empty() {
+        fund_msgs_vec.push(CosmosMsg::Bank(BankMsg::Send {
+            to_address: env.contract.address.to_string(),
+            amount: info.funds.clone(),
+        }))
+    }
+
+    for cw_fund in &cw_funds_vec {
+        fund_msgs_vec.push(CosmosMsg::Wasm(match cw_fund {
+            Fund::Cw20(cw20_fund) => WasmMsg::Execute {
+                contract_addr: deps
+                    .api
+                    .addr_validate(&cw20_fund.contract_addr)?
+                    .to_string(),
+                msg: to_binary(&FundTransferMsgs::TransferFrom(TransferFromMsg {
+                    owner: msg.owner.clone().to_string(),
+                    recipient: env.contract.address.clone().to_string(),
+                    amount: cw20_fund.amount,
+                }))?,
+                funds: vec![],
+            },
+            Fund::Cw721(cw721_fund) => WasmMsg::Execute {
+                contract_addr: deps
+                    .api
+                    .addr_validate(&cw721_fund.contract_addr)?
+                    .to_string(),
+                msg: to_binary(&FundTransferMsgs::TransferNft(TransferNftMsg {
+                    recipient: env.contract.address.clone().to_string(),
+                    token_id: cw721_fund.token_id.clone(),
+                }))?,
+                funds: vec![],
+            },
+        }));
+    }
+
     Ok(Response::new()
         .add_attribute("action", "instantiate")
         .add_attribute("contract_addr", env.contract.address)
         .add_attribute("owner", msg.owner)
         .add_attribute("funds", serde_json_wasm::to_string(&info.funds)?)
-        .add_attribute("cw_funds", serde_json_wasm::to_string(&msg.funds)?))
+        .add_attribute("cw_funds", serde_json_wasm::to_string(&msg.funds)?)
+        .add_messages(fund_msgs_vec)
+        .add_messages(msg.msgs.unwrap_or(vec![])))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -1,4 +1,3 @@
-use cosmwasm_schema::cw_serde;
 use crate::error::map_contract_error;
 use crate::state::{ACCOUNTS, CONFIG, FINISHED_JOBS, PENDING_JOBS};
 use crate::util::variable::apply_var_fn;
@@ -7,7 +6,12 @@ use account::{GenericMsg, WithdrawAssetsMsg};
 use controller::account::{Account, Fund, FundTransferMsgs, TransferFromMsg, TransferNftMsg};
 use controller::job::{Job, JobStatus};
 use controller::{Config, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, State};
-use cosmwasm_std::{entry_point, to_binary, Attribute, BalanceResponse, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest, Reply, Response, StdError, StdResult, SubMsgResult, Uint128, Uint64, WasmMsg, Addr};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{
+    entry_point, to_binary, Addr, Attribute, BalanceResponse, BankMsg, BankQuery, Binary, Coin,
+    CosmosMsg, Deps, DepsMut, Env, MessageInfo, QueryRequest, Reply, Response, StdError, StdResult,
+    SubMsgResult, Uint128, Uint64, WasmMsg,
+};
 use cw_storage_plus::Item;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -146,8 +150,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
 
     Ok(Response::new()
         .add_attribute("action", "migrate")
-        .add_attribute("fee_denom", new_config.fee_denom)
-    )
+        .add_attribute("fee_denom", new_config.fee_denom))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -389,7 +392,10 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                             msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg {
                                 msgs: vec![CosmosMsg::Bank(BankMsg::Send {
                                     to_address: env.contract.address.to_string(),
-                                    amount: vec![Coin::new((new_job.reward).u128(), config.fee_denom)],
+                                    amount: vec![Coin::new(
+                                        (new_job.reward).u128(),
+                                        config.fee_denom,
+                                    )],
                                 })],
                             }))?,
                             funds: vec![],

--- a/contracts/warp-controller/src/execute/account.rs
+++ b/contracts/warp-controller/src/execute/account.rs
@@ -85,6 +85,7 @@ pub fn create_account(
             admin: Some(env.contract.address.to_string()),
             code_id: config.warp_account_code_id.u64(),
             msg: to_binary(&account::InstantiateMsg {
+                msgs: data.msgs,
                 owner: info.sender.to_string(),
                 funds: data.funds,
             })?,

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -207,7 +207,10 @@ pub fn delete_job(
         //send reward minus fee back to account
         BankMsg::Send {
             to_address: account.account.to_string(),
-            amount: vec![Coin::new((job.reward - fee).u128(), config.fee_denom.clone())],
+            amount: vec![Coin::new(
+                (job.reward - fee).u128(),
+                config.fee_denom.clone(),
+            )],
         },
         BankMsg::Send {
             to_address: config.fee_collector.to_string(),

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -137,6 +137,19 @@ pub fn create_job(
         },
     ];
 
+    let mut account_msgs: Vec<WasmMsg> = vec![];
+
+    match data.account_msgs {
+        Some(msgs) => {
+            account_msgs = vec![WasmMsg::Execute {
+                contract_addr: account.account.to_string(),
+                msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg { msgs }))?,
+                funds: vec![],
+            }];
+        }
+        None => {}
+    }
+
     Ok(Response::new()
         .add_messages(reward_send_msgs)
         .add_attribute("action", "create_job")
@@ -148,7 +161,8 @@ pub fn create_job(
         .add_attribute("job_msgs", serde_json_wasm::to_string(&job.msgs)?)
         .add_attribute("job_reward", job.reward)
         .add_attribute("job_creation_fee", fee)
-        .add_attribute("job_last_updated_time", job.last_update_time))
+        .add_attribute("job_last_updated_time", job.last_update_time)
+        .add_messages(account_msgs))
 }
 
 pub fn delete_job(

--- a/contracts/warp-resolver/src/contract.rs
+++ b/contracts/warp-resolver/src/contract.rs
@@ -1,8 +1,11 @@
-use cosmwasm_schema::cw_serde;
 use crate::state::{CONFIG, QUERY_PAGE_SIZE, STATE, TEMPLATES};
 use crate::ContractError;
 use controller::MigrateMsg;
-use cosmwasm_std::{entry_point, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Order, Response, StdError, StdResult, Uint64, Addr, Uint128};
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{
+    entry_point, to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env,
+    MessageInfo, Order, Response, StdError, StdResult, Uint128, Uint64,
+};
 use cw_storage_plus::{Bound, Item};
 use resolver::{
     Config, ConfigResponse, DeleteTemplateMsg, EditTemplateMsg, ExecuteMsg, InstantiateMsg,

--- a/packages/account/src/lib.rs
+++ b/packages/account/src/lib.rs
@@ -11,6 +11,7 @@ pub struct Config {
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
+    pub msgs: Option<Vec<CosmosMsg>>,
     pub funds: Option<Vec<Fund>>,
 }
 

--- a/packages/controller/src/account.rs
+++ b/packages/controller/src/account.rs
@@ -1,9 +1,10 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::{Addr, CosmosMsg, Uint128};
 
 #[cw_serde]
 pub struct CreateAccountMsg {
     pub funds: Option<Vec<Fund>>,
+    pub msgs: Option<Vec<CosmosMsg>>,
 }
 
 #[cw_serde]

--- a/packages/controller/src/job.rs
+++ b/packages/controller/src/job.rs
@@ -1,7 +1,7 @@
 use crate::account::AssetInfo;
 use crate::condition::Condition;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Uint128, Uint64};
+use cosmwasm_std::{Addr, Uint128, Uint64, CosmosMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
@@ -67,6 +67,7 @@ pub struct CreateJobMsg {
     pub requeue_on_evict: bool,
     pub reward: Uint128,
     pub assets_to_withdraw: Option<Vec<AssetInfo>>,
+    pub account_msgs: Option<Vec<CosmosMsg>>,
 }
 
 #[cw_serde]

--- a/packages/controller/src/job.rs
+++ b/packages/controller/src/job.rs
@@ -1,7 +1,7 @@
 use crate::account::AssetInfo;
 use crate::condition::Condition;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Uint128, Uint64, CosmosMsg};
+use cosmwasm_std::{Addr, CosmosMsg, Uint128, Uint64};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;


### PR DESCRIPTION
Adds following capabilities to create_account instantiate:
- cw20/cw721 funding logic provided by info.funds
- optional msgs array in CreateAccountMsg to be executed post funding 
- create_job accepts a account_msgs arg, which is just a generic msg passthrough to account
  - useful for atomic use case when account addr is unknown