### PR TITLE
[Chore] Add prev id and remove need for account for keeper

### DIFF
--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -314,6 +314,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
             job_key,
             &Job {
                 id: v1_job.id,
+                prev_id: None,
                 owner: v1_job.owner,
                 last_update_time: v1_job.last_update_time,
                 name: v1_job.name,
@@ -398,6 +399,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
             job_key,
             &Job {
                 id: v1_job.id,
+                prev_id: None,
                 owner: v1_job.owner,
                 last_update_time: v1_job.last_update_time,
                 name: v1_job.name,
@@ -545,6 +547,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
             let finished_job = FINISHED_JOBS().update(deps.storage, msg.id, |j| match j {
                 None => Ok(Job {
                     id: job.id,
+                    prev_id: job.prev_id,
                     owner: job.owner,
                     last_update_time: job.last_update_time,
                     name: job.name,
@@ -666,6 +669,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                             |s| match s {
                                 None => Ok(Job {
                                     id: state.current_job_id,
+                                    prev_id: Some(finished_job.id),
                                     owner: finished_job.owner.clone(),
                                     last_update_time: Uint64::from(env.block.time.seconds()),
                                     name: finished_job.name.clone(),

--- a/contracts/warp-controller/src/execute/controller.rs
+++ b/contracts/warp-controller/src/execute/controller.rs
@@ -274,6 +274,7 @@ pub fn migrate_pending_jobs(
             job_key,
             &Job {
                 id: v1_job.id,
+                prev_id: None,
                 owner: v1_job.owner,
                 last_update_time: v1_job.last_update_time,
                 name: v1_job.name,
@@ -376,6 +377,7 @@ pub fn migrate_finished_jobs(
             job_key,
             &Job {
                 id: v1_job.id,
+                prev_id: None,
                 owner: v1_job.owner,
                 last_update_time: v1_job.last_update_time,
                 name: v1_job.name,

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -318,12 +318,6 @@ pub fn execute_job(
     let job = PENDING_JOBS().load(deps.storage, data.id.u64())?;
     let account = ACCOUNTS().load(deps.storage, job.owner.clone())?;
 
-    if !ACCOUNTS().has(deps.storage, info.sender.clone()) {
-        return Err(ContractError::AccountDoesNotExist {});
-    }
-
-    let keeper_account = ACCOUNTS().load(deps.storage, info.sender.clone())?;
-
     if job.status != JobStatus::Pending {
         return Err(ContractError::JobNotActive {});
     }
@@ -407,8 +401,9 @@ pub fn execute_job(
         });
     }
 
+    //send reward to executor
     let reward_msg = BankMsg::Send {
-        to_address: keeper_account.account.to_string(),
+        to_address: info.sender.to_string(),
         amount: vec![Coin::new(job.reward.u128(), config.fee_denom)],
     };
 

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -60,6 +60,7 @@ pub fn create_job(
     let job = PENDING_JOBS().update(deps.storage, state.current_job_id.u64(), |s| match s {
         None => Ok(Job {
             id: state.current_job_id,
+            prev_id: None,
             owner: account.owner,
             last_update_time: Uint64::from(env.block.time.seconds()),
             name: data.name,
@@ -151,6 +152,7 @@ pub fn delete_job(
     let _new_job = FINISHED_JOBS().update(deps.storage, data.id.u64(), |h| match h {
         None => Ok(Job {
             id: job.id,
+            prev_id: job.prev_id,
             owner: job.owner,
             last_update_time: job.last_update_time,
             name: job.name,
@@ -231,6 +233,7 @@ pub fn update_job(
         None => Err(ContractError::JobDoesNotExist {}),
         Some(job) => Ok(Job {
             id: job.id,
+            prev_id: job.prev_id,
             owner: job.owner,
             last_update_time: if added_reward > config.minimum_reward {
                 Uint64::new(env.block.time.seconds())
@@ -353,6 +356,7 @@ pub fn execute_job(
             data.id.u64(),
             &Job {
                 id: job.id,
+                prev_id: job.prev_id,
                 owner: job.owner,
                 last_update_time: job.last_update_time,
                 name: job.name,
@@ -481,6 +485,7 @@ pub fn evict_job(
                 None => Err(ContractError::JobDoesNotExist {}),
                 Some(job) => Ok(Job {
                     id: job.id,
+                    prev_id: job.prev_id,
                     owner: job.owner,
                     last_update_time: Uint64::new(env.block.time.seconds()),
                     name: job.name,
@@ -504,6 +509,7 @@ pub fn evict_job(
             .update(deps.storage, data.id.u64(), |j| match j {
                 None => Ok(Job {
                     id: job.id,
+                    prev_id: job.prev_id,
                     owner: job.owner,
                     last_update_time: Uint64::new(env.block.time.seconds()),
                     name: job.name,

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -397,8 +397,7 @@ pub fn evict_job(
         );
         job_status = JobQueue::sync(&mut deps, env, job.clone())?.status;
     } else {
-        job_status =
-            JobQueue::finalize(&mut deps, env, job.id.into(), JobStatus::Evicted)?.status;
+        job_status = JobQueue::finalize(&mut deps, env, job.id.into(), JobStatus::Evicted)?.status;
 
         cosmos_msgs.append(&mut vec![
             //send reward minus fee back to account

--- a/contracts/warp-controller/src/state.rs
+++ b/contracts/warp-controller/src/state.rs
@@ -107,6 +107,7 @@ impl JobQueue {
             None => Err(ContractError::JobDoesNotExist {}),
             Some(job) => Ok(Job {
                 id: job.id,
+                prev_id: job.prev_id,
                 owner: job.owner,
                 last_update_time: Uint64::new(env.block.time.seconds()),
                 name: job.name,
@@ -133,6 +134,7 @@ impl JobQueue {
             None => Err(ContractError::JobDoesNotExist {}),
             Some(job) => Ok(Job {
                 id: job.id,
+                prev_id: job.prev_id,
                 owner: job.owner,
                 last_update_time: if added_reward > config.minimum_reward {
                     Uint64::new(env.block.time.seconds())
@@ -169,6 +171,7 @@ impl JobQueue {
 
         let new_job = Job {
             id: job.id,
+            prev_id: job.prev_id,
             owner: job.owner,
             last_update_time: Uint64::new(env.block.time.seconds()),
             name: job.name,

--- a/packages/controller/src/job.rs
+++ b/packages/controller/src/job.rs
@@ -22,6 +22,8 @@ use strum_macros::Display;
 #[cw_serde]
 pub struct Job {
     pub id: Uint64,
+    // Exist if job is the follow up job of a recurring job
+    pub prev_id: Option<Uint64>,
     pub owner: Addr,
     pub last_update_time: Uint64,
     pub name: String,


### PR DESCRIPTION
1. add `prev_id` to job struct https://github.com/terra-money/warp-contracts/issues/50
2. send execution reward straight to keeper instead of keeper's warp account https://github.com/terra-money/warp-contracts/issues/41