### PR TITLE
[Feature] Support env var like warp account addr

### DIFF
--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -390,6 +390,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                                     resolver::QueryResolveConditionMsg {
                                         condition: terminate_condition,
                                         vars: new_vars.clone(),
+                                        warp_account_addr: Some(account.account.to_string()),
                                     },
                                 ),
                             );

--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -119,74 +119,74 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-// #[cfg_attr(not(feature = "library"), entry_point)]
-// pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
-//     //STATE
-//     #[cw_serde]
-//     pub struct V1State {
-//         pub current_job_id: Uint64,
-//         pub current_template_id: Uint64,
-//         pub q: Uint64,
-//     }
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    //STATE
+    #[cw_serde]
+    pub struct V1State {
+        pub current_job_id: Uint64,
+        pub current_template_id: Uint64,
+        pub q: Uint64,
+    }
 
-//     const V1STATE: Item<V1State> = Item::new("state");
-//     let v1_state = V1STATE.load(deps.storage)?;
+    const V1STATE: Item<V1State> = Item::new("state");
+    let v1_state = V1STATE.load(deps.storage)?;
 
-//     STATE.save(
-//         deps.storage,
-//         &State {
-//             current_job_id: v1_state.current_job_id,
-//             q: v1_state.q,
-//         },
-//     )?;
+    STATE.save(
+        deps.storage,
+        &State {
+            current_job_id: v1_state.current_job_id,
+            q: v1_state.q,
+        },
+    )?;
 
-//     //CONFIG
-//     #[cw_serde]
-//     pub struct V1Config {
-//         pub owner: Addr,
-//         pub fee_denom: String,
-//         pub fee_collector: Addr,
-//         pub warp_account_code_id: Uint64,
-//         pub minimum_reward: Uint128,
-//         pub creation_fee_percentage: Uint64,
-//         pub cancellation_fee_percentage: Uint64,
-//         // maximum time for evictions
-//         pub t_max: Uint64,
-//         // minimum time for evictions
-//         pub t_min: Uint64,
-//         // maximum fee for evictions
-//         pub a_max: Uint128,
-//         // minimum fee for evictions
-//         pub a_min: Uint128,
-//         // maximum length of queue modifier for evictions
-//         pub q_max: Uint64,
-//     }
+    //CONFIG
+    #[cw_serde]
+    pub struct V1Config {
+        pub owner: Addr,
+        pub fee_denom: String,
+        pub fee_collector: Addr,
+        pub warp_account_code_id: Uint64,
+        pub minimum_reward: Uint128,
+        pub creation_fee_percentage: Uint64,
+        pub cancellation_fee_percentage: Uint64,
+        // maximum time for evictions
+        pub t_max: Uint64,
+        // minimum time for evictions
+        pub t_min: Uint64,
+        // maximum fee for evictions
+        pub a_max: Uint128,
+        // minimum fee for evictions
+        pub a_min: Uint128,
+        // maximum length of queue modifier for evictions
+        pub q_max: Uint64,
+    }
 
-//     const V1CONFIG: Item<V1Config> = Item::new("config");
+    const V1CONFIG: Item<V1Config> = Item::new("config");
 
-//     let v1_config = V1CONFIG.load(deps.storage)?;
+    let v1_config = V1CONFIG.load(deps.storage)?;
 
-//     CONFIG.save(
-//         deps.storage,
-//         &Config {
-//             owner: v1_config.owner,
-//             fee_denom: v1_config.fee_denom,
-//             fee_collector: v1_config.fee_collector,
-//             warp_account_code_id: msg.warp_account_code_id,
-//             minimum_reward: v1_config.minimum_reward,
-//             creation_fee_percentage: v1_config.creation_fee_percentage,
-//             cancellation_fee_percentage: v1_config.cancellation_fee_percentage,
-//             resolver_address: deps.api.addr_validate(&msg.resolver_address)?,
-//             t_max: v1_config.t_max,
-//             t_min: v1_config.t_min,
-//             a_max: v1_config.a_max,
-//             a_min: v1_config.a_min,
-//             q_max: v1_config.q_max,
-//         },
-//     )?;
+    CONFIG.save(
+        deps.storage,
+        &Config {
+            owner: v1_config.owner,
+            fee_denom: v1_config.fee_denom,
+            fee_collector: v1_config.fee_collector,
+            warp_account_code_id: msg.warp_account_code_id,
+            minimum_reward: v1_config.minimum_reward,
+            creation_fee_percentage: v1_config.creation_fee_percentage,
+            cancellation_fee_percentage: v1_config.cancellation_fee_percentage,
+            resolver_address: deps.api.addr_validate(&msg.resolver_address)?,
+            t_max: v1_config.t_max,
+            t_min: v1_config.t_min,
+            a_max: v1_config.a_max,
+            a_min: v1_config.a_min,
+            q_max: v1_config.q_max,
+        },
+    )?;
 
-//     Ok(Response::new())
-// }
+    Ok(Response::new())
+}
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {
@@ -377,6 +377,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                         &resolver::QueryMsg::QueryApplyVarFn(resolver::QueryApplyVarFnMsg {
                             vars: finished_job.vars,
                             status: finished_job.status.clone(),
+                            warp_account_addr: Some(account.account.to_string()),
                         }),
                     )?;
 

--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -119,74 +119,74 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     }
 }
 
-#[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
-    //STATE
-    #[cw_serde]
-    pub struct V1State {
-        pub current_job_id: Uint64,
-        pub current_template_id: Uint64,
-        pub q: Uint64,
-    }
+// #[cfg_attr(not(feature = "library"), entry_point)]
+// pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+//     //STATE
+//     #[cw_serde]
+//     pub struct V1State {
+//         pub current_job_id: Uint64,
+//         pub current_template_id: Uint64,
+//         pub q: Uint64,
+//     }
 
-    const V1STATE: Item<V1State> = Item::new("state");
-    let v1_state = V1STATE.load(deps.storage)?;
+//     const V1STATE: Item<V1State> = Item::new("state");
+//     let v1_state = V1STATE.load(deps.storage)?;
 
-    STATE.save(
-        deps.storage,
-        &State {
-            current_job_id: v1_state.current_job_id,
-            q: v1_state.q,
-        },
-    )?;
+//     STATE.save(
+//         deps.storage,
+//         &State {
+//             current_job_id: v1_state.current_job_id,
+//             q: v1_state.q,
+//         },
+//     )?;
 
-    //CONFIG
-    #[cw_serde]
-    pub struct V1Config {
-        pub owner: Addr,
-        pub fee_denom: String,
-        pub fee_collector: Addr,
-        pub warp_account_code_id: Uint64,
-        pub minimum_reward: Uint128,
-        pub creation_fee_percentage: Uint64,
-        pub cancellation_fee_percentage: Uint64,
-        // maximum time for evictions
-        pub t_max: Uint64,
-        // minimum time for evictions
-        pub t_min: Uint64,
-        // maximum fee for evictions
-        pub a_max: Uint128,
-        // minimum fee for evictions
-        pub a_min: Uint128,
-        // maximum length of queue modifier for evictions
-        pub q_max: Uint64,
-    }
+//     //CONFIG
+//     #[cw_serde]
+//     pub struct V1Config {
+//         pub owner: Addr,
+//         pub fee_denom: String,
+//         pub fee_collector: Addr,
+//         pub warp_account_code_id: Uint64,
+//         pub minimum_reward: Uint128,
+//         pub creation_fee_percentage: Uint64,
+//         pub cancellation_fee_percentage: Uint64,
+//         // maximum time for evictions
+//         pub t_max: Uint64,
+//         // minimum time for evictions
+//         pub t_min: Uint64,
+//         // maximum fee for evictions
+//         pub a_max: Uint128,
+//         // minimum fee for evictions
+//         pub a_min: Uint128,
+//         // maximum length of queue modifier for evictions
+//         pub q_max: Uint64,
+//     }
 
-    const V1CONFIG: Item<V1Config> = Item::new("config");
+//     const V1CONFIG: Item<V1Config> = Item::new("config");
 
-    let v1_config = V1CONFIG.load(deps.storage)?;
+//     let v1_config = V1CONFIG.load(deps.storage)?;
 
-    CONFIG.save(
-        deps.storage,
-        &Config {
-            owner: v1_config.owner,
-            fee_denom: v1_config.fee_denom,
-            fee_collector: v1_config.fee_collector,
-            warp_account_code_id: msg.warp_account_code_id,
-            minimum_reward: v1_config.minimum_reward,
-            creation_fee_percentage: v1_config.creation_fee_percentage,
-            cancellation_fee_percentage: v1_config.cancellation_fee_percentage,
-            resolver_address: deps.api.addr_validate(&msg.resolver_address)?,
-            t_max: v1_config.t_max,
-            t_min: v1_config.t_min,
-            a_max: v1_config.a_max,
-            a_min: v1_config.a_min,
-            q_max: v1_config.q_max,
-        },
-    )?;
+//     CONFIG.save(
+//         deps.storage,
+//         &Config {
+//             owner: v1_config.owner,
+//             fee_denom: v1_config.fee_denom,
+//             fee_collector: v1_config.fee_collector,
+//             warp_account_code_id: msg.warp_account_code_id,
+//             minimum_reward: v1_config.minimum_reward,
+//             creation_fee_percentage: v1_config.creation_fee_percentage,
+//             cancellation_fee_percentage: v1_config.cancellation_fee_percentage,
+//             resolver_address: deps.api.addr_validate(&msg.resolver_address)?,
+//             t_max: v1_config.t_max,
+//             t_min: v1_config.t_min,
+//             a_max: v1_config.a_max,
+//             a_min: v1_config.a_min,
+//             q_max: v1_config.q_max,
+//         },
+//     )?;
 
-    Ok(Response::new())
-}
+//     Ok(Response::new())
+// }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {

--- a/contracts/warp-controller/src/execute/controller.rs
+++ b/contracts/warp-controller/src/execute/controller.rs
@@ -9,10 +9,10 @@ use cosmwasm_std::{
     to_binary, Addr, DepsMut, Env, MessageInfo, Order, Response, Uint128, Uint64, WasmMsg,
 };
 use cw_storage_plus::{Bound, Index, IndexList, IndexedMap, MultiIndex, UniqueIndex};
-use resolver::condition::Condition;
+use resolver::condition::{Condition, StringValue};
 use resolver::variable::{
-    ExternalExpr, ExternalVariable, QueryExpr, QueryVariable, StaticVariable, UpdateFn, Variable,
-    VariableKind,
+    ExternalExpr, ExternalVariable, FnValue, QueryExpr, QueryVariable, StaticVariable, UpdateFn,
+    Variable, VariableKind,
 };
 
 //JOBS
@@ -237,7 +237,9 @@ pub fn migrate_pending_jobs(
                     kind: v.kind,
                     name: v.name,
                     encode: false,
-                    value: v.value,
+                    init_fn: FnValue::String(StringValue::Simple(v.value.clone())),
+                    reinitialize: false,
+                    value: Some(v.value.clone()),
                     update_fn: v.update_fn,
                 }),
                 V1Variable::External(v) => Variable::External(ExternalVariable {
@@ -339,7 +341,9 @@ pub fn migrate_finished_jobs(
                     kind: v.kind,
                     name: v.name,
                     encode: false,
-                    value: v.value,
+                    init_fn: FnValue::String(StringValue::Simple(v.value.clone())),
+                    reinitialize: false,
+                    value: Some(v.value.clone()),
                     update_fn: v.update_fn,
                 }),
                 V1Variable::External(v) => Variable::External(ExternalVariable {

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -330,6 +330,7 @@ pub fn execute_job(
         &resolver::QueryMsg::QueryHydrateVars(resolver::QueryHydrateVarsMsg {
             vars: job.vars,
             external_inputs: data.external_inputs,
+            warp_account_addr: Some(account.account.to_string()),
         }),
     )?;
 

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -403,8 +403,7 @@ pub fn evict_job(
         );
         job_status = JobQueue::sync(&mut deps, env, job.clone())?.status;
     } else {
-        job_status =
-            JobQueue::finalize(&mut deps, env, job.id.into(), JobStatus::Evicted)?.status;
+        job_status = JobQueue::finalize(&mut deps, env, job.id.into(), JobStatus::Evicted)?.status;
 
         cosmos_msgs.append(&mut vec![
             //send reward minus fee back to account

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -339,6 +339,7 @@ pub fn execute_job(
         &resolver::QueryMsg::QueryResolveCondition(resolver::QueryResolveConditionMsg {
             condition: job.condition,
             vars: vars.clone(),
+            warp_account_addr: Some(account.account.to_string()),
         }),
     );
 

--- a/contracts/warp-resolver/src/contract.rs
+++ b/contracts/warp-resolver/src/contract.rs
@@ -125,6 +125,7 @@ pub fn execute_resolve_condition(
         QueryResolveConditionMsg {
             condition: data.condition,
             vars: data.vars,
+            warp_account_addr: data.warp_account_addr,
         },
     )?;
 
@@ -265,7 +266,8 @@ fn query_resolve_condition(
     let vars: Vec<Variable> =
         serde_json_wasm::from_str(&data.vars).map_err(|e| StdError::generic_err(e.to_string()))?;
 
-    resolve_cond(deps, env, condition, &vars).map_err(|e| StdError::generic_err(e.to_string()))
+    resolve_cond(deps, env, condition, &vars, data.warp_account_addr)
+        .map_err(|e| StdError::generic_err(e.to_string()))
 }
 
 fn query_apply_var_fn(deps: Deps, env: Env, data: QueryApplyVarFnMsg) -> StdResult<String> {

--- a/contracts/warp-resolver/src/contract.rs
+++ b/contracts/warp-resolver/src/contract.rs
@@ -104,6 +104,7 @@ pub fn execute_hydrate_vars(
         QueryHydrateVarsMsg {
             vars: data.vars,
             external_inputs: data.external_inputs,
+            warp_account_addr: data.warp_account_addr,
         },
     )?;
 
@@ -241,8 +242,14 @@ fn query_hydrate_vars(deps: Deps, env: Env, data: QueryHydrateVarsMsg) -> StdRes
     let vars: Vec<Variable> =
         serde_json_wasm::from_str(&data.vars).map_err(|e| StdError::generic_err(e.to_string()))?;
     serde_json_wasm::to_string(
-        &hydrate_vars(deps, env, vars, data.external_inputs)
-            .map_err(|e| StdError::generic_err(e.to_string()))?,
+        &hydrate_vars(
+            deps,
+            env,
+            vars,
+            data.external_inputs,
+            data.warp_account_addr,
+        )
+        .map_err(|e| StdError::generic_err(e.to_string()))?,
     )
     .map_err(|e| StdError::generic_err(e.to_string()))
 }

--- a/contracts/warp-resolver/src/contract.rs
+++ b/contracts/warp-resolver/src/contract.rs
@@ -145,6 +145,7 @@ pub fn execute_apply_var_fn(
         QueryApplyVarFnMsg {
             vars: data.vars,
             status: data.status,
+            warp_account_addr: data.warp_account_addr,
         },
     )?;
     Ok(Response::new()
@@ -271,7 +272,8 @@ fn query_apply_var_fn(deps: Deps, env: Env, data: QueryApplyVarFnMsg) -> StdResu
     let vars: Vec<Variable> =
         serde_json_wasm::from_str(&data.vars).map_err(|e| StdError::generic_err(e.to_string()))?;
 
-    apply_var_fn(deps, env, vars, data.status).map_err(|e| StdError::generic_err(e.to_string()))
+    apply_var_fn(deps, env, vars, data.status, data.warp_account_addr)
+        .map_err(|e| StdError::generic_err(e.to_string()))
 }
 
 fn query_hydrate_msgs(

--- a/contracts/warp-resolver/src/tests.rs
+++ b/contracts/warp-resolver/src/tests.rs
@@ -1,444 +1,559 @@
-// use schemars::_serde_json::json;
+use resolver::condition::{StringEnvValue, StringValue};
+use schemars::_serde_json::json;
 
-// use crate::util::variable::{hydrate_msgs, hydrate_vars};
+use crate::util::variable::{hydrate_msgs, hydrate_vars};
 
-// use cosmwasm_std::{testing::mock_env, WasmQuery};
-// use cosmwasm_std::{to_binary, BankQuery, Binary, ContractResult, CosmosMsg, OwnedDeps, WasmMsg};
+use cosmwasm_std::{testing::mock_env, WasmQuery};
+use cosmwasm_std::{to_binary, BankQuery, Binary, ContractResult, CosmosMsg, OwnedDeps, WasmMsg};
 
-// use crate::contract::query;
-// use cosmwasm_schema::cw_serde;
-// use cosmwasm_std::testing::{mock_info, MockApi, MockQuerier, MockStorage};
-// use cosmwasm_std::{from_slice, Empty, Querier, QueryRequest, SystemError, SystemResult};
+use crate::contract::query;
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::testing::{mock_info, MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{from_slice, Empty, Querier, QueryRequest, SystemError, SystemResult};
 
-// use resolver::variable::{
-//     InitFnValue, QueryExpr, QueryVariable, StaticVariable, StringValue, Variable, VariableKind,
-// };
-// use resolver::{QueryMsg, QueryValidateJobCreationMsg};
-// use std::marker::PhantomData;
+use resolver::variable::{
+    FnValue, QueryExpr, QueryVariable, StaticVariable, Variable, VariableKind,
+};
+use resolver::{QueryMsg, QueryValidateJobCreationMsg};
+use std::marker::PhantomData;
 
-// #[test]
-// fn test() {
-//     let deps = mock_dependencies();
-//     let _info = mock_info("vlad", &[]);
-//     let env = mock_env();
-//     let msg = QueryValidateJobCreationMsg {
-//         condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
-//         terminate_condition: None,
-//         vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
-//         msgs: "[{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}]".to_string(),
-//     };
-//     let obj = serde_json_wasm::to_string(&vec!["{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}"]).unwrap();
+#[cw_serde]
+struct TestStruct {
+    test: String,
+}
 
-//     let _msg1 = QueryValidateJobCreationMsg {
-//         condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
-//         terminate_condition: None,
-//         vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
-//         msgs: obj.clone(),
-//     };
+#[test]
+fn test() {
+    let deps = mock_dependencies();
+    let _info = mock_info("vlad", &[]);
+    let env = mock_env();
+    let msg = QueryValidateJobCreationMsg {
+        condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
+        terminate_condition: None,
+        vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
+        msgs: "[{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}]".to_string(),
+    };
+    let obj = serde_json_wasm::to_string(&vec!["{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}"]).unwrap();
 
-//     println!("{}", serde_json_wasm::to_string(&obj).unwrap());
+    let _msg1 = QueryValidateJobCreationMsg {
+        condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
+        terminate_condition: None,
+        vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
+        msgs: obj.clone(),
+    };
 
-//     let test = query(deps.as_ref(), env, QueryMsg::QueryValidateJobCreation(msg)).unwrap();
-//     println!("{}", test)
-// }
+    println!("{}", serde_json_wasm::to_string(&obj).unwrap());
 
-// #[test]
-// fn test_vars() {
-//     let test_msg = "{\"execute\":{\"test\":\"$WARPVAR.test\"}}".to_string();
+    let test = query(deps.as_ref(), env, QueryMsg::QueryValidateJobCreation(msg)).unwrap();
+    println!("{}", test)
+}
 
-//     let _idx = test_msg.find("\"$WARPVAR\"");
+#[test]
+fn test_vars() {
+    let test_msg = "{\"execute\":{\"test\":\"$WARPVAR.test\"}}".to_string();
 
-//     let _new_str = test_msg.replace("\"$WARPVAR.test\"", "\"input\"");
-// }
+    let _idx = test_msg.find("\"$WARPVAR\"");
 
-// pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
-//     let custom_querier: WasmMockQuerier = WasmMockQuerier::new(MockQuerier::new(&[]));
+    let _new_str = test_msg.replace("\"$WARPVAR.test\"", "\"input\"");
+}
 
-//     OwnedDeps {
-//         api: MockApi::default(),
-//         storage: MockStorage::default(),
-//         querier: custom_querier,
-//         custom_query_type: PhantomData,
-//     }
-// }
+pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+    let custom_querier: WasmMockQuerier = WasmMockQuerier::new(MockQuerier::new(&[]));
 
-// pub struct WasmMockQuerier {
-//     base: MockQuerier<Empty>,
-// }
+    OwnedDeps {
+        api: MockApi::default(),
+        storage: MockStorage::default(),
+        querier: custom_querier,
+        custom_query_type: PhantomData,
+    }
+}
 
-// impl Querier for WasmMockQuerier {
-//     fn raw_query(&self, bin_request: &[u8]) -> SystemResult<ContractResult<Binary>> {
-//         let request: QueryRequest<Empty> = match from_slice(bin_request) {
-//             Ok(v) => v,
-//             Err(e) => {
-//                 return SystemResult::Err(SystemError::InvalidRequest {
-//                     error: format!("Parsing query request: {}", e),
-//                     request: bin_request.into(),
-//                 });
-//             }
-//         };
-//         self.handle_query(&request)
-//     }
-// }
+pub struct WasmMockQuerier {
+    base: MockQuerier<Empty>,
+}
 
-// impl WasmMockQuerier {
-//     pub fn handle_query(
-//         &self,
-//         request: &QueryRequest<Empty>,
-//     ) -> SystemResult<ContractResult<Binary>> {
-//         match &request {
-//             QueryRequest::Wasm(WasmQuery::Smart {
-//                 contract_addr,
-//                 msg: _,
-//             }) => {
-//                 // Mock logic for the Wasm::Smart case
-//                 // Here for simplicity, we return the contract_addr and msg as is.
+impl Querier for WasmMockQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> SystemResult<ContractResult<Binary>> {
+        let request: QueryRequest<Empty> = match from_slice(bin_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: format!("Parsing query request: {}", e),
+                    request: bin_request.into(),
+                });
+            }
+        };
+        self.handle_query(&request)
+    }
+}
 
-//                 // Mock logic for the Wasm::Smart case
-//                 // Here we return a JSON object with "address" and "msg" fields.
-//                 let response: String = json!({
-//                     "address": contract_addr,
-//                     "msg": "Mock message"
-//                 })
-//                 .to_string();
+impl WasmMockQuerier {
+    pub fn handle_query(
+        &self,
+        request: &QueryRequest<Empty>,
+    ) -> SystemResult<ContractResult<Binary>> {
+        match &request {
+            QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr,
+                msg: _,
+            }) => {
+                // Mock logic for the Wasm::Smart case
+                // Here for simplicity, we return the contract_addr and msg as is.
 
-//                 SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
-//             }
-//             QueryRequest::Bank(BankQuery::Balance {
-//                 address: contract_addr,
-//                 denom: _,
-//             }) => SystemResult::Ok(ContractResult::Ok(
-//                 to_binary(&contract_addr.to_string()).unwrap(),
-//             )),
-//             _ => self.base.handle_query(request),
-//         }
-//     }
-// }
+                // Mock logic for the Wasm::Smart case
+                // Here we return a JSON object with "address" and "msg" fields.
+                let response: String = json!({
+                    "address": contract_addr,
+                    "msg": "Mock message"
+                })
+                .to_string();
 
-// impl WasmMockQuerier {
-//     pub fn new(base: MockQuerier<Empty>) -> Self {
-//         WasmMockQuerier { base }
-//     }
-// }
+                SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+            }
+            QueryRequest::Bank(BankQuery::Balance {
+                address: contract_addr,
+                denom: _,
+            }) => SystemResult::Ok(ContractResult::Ok(
+                to_binary(&contract_addr.to_string()).unwrap(),
+            )),
+            _ => self.base.handle_query(request),
+        }
+    }
+}
 
-// #[test]
-// fn test_hydrate_vars_nested_variables_binary_json() {
-//     let deps = mock_dependencies();
-//     let env = mock_env();
+impl WasmMockQuerier {
+    pub fn new(base: MockQuerier<Empty>) -> Self {
+        WasmMockQuerier { base }
+    }
+}
 
-//     let var5 = Variable::Static(StaticVariable {
-//         kind: VariableKind::String,
-//         name: "var5".to_string(),
-//         encode: false,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Simple("contract_addr".to_string())),
-//         update_fn: None,
-//     });
+#[test]
+fn test_hydrate_vars_nested_variables_binary_json() {
+    let deps = mock_dependencies();
+    let env = mock_env();
 
-//     let var4 = Variable::Static(StaticVariable {
-//         kind: VariableKind::String,
-//         name: "var4".to_string(),
-//         encode: false,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Ref("$warp.variable.var5".to_string())),
-//         update_fn: None,
-//     });
+    let var5 = Variable::Static(StaticVariable {
+        kind: VariableKind::String,
+        name: "var5".to_string(),
+        encode: false,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple("contract_addr".to_string())),
+        reinitialize: false,
+        update_fn: None,
+    });
 
-//     let var3 = Variable::Query(QueryVariable {
-//         name: "var3".to_string(),
-//         kind: VariableKind::Json,
-//         init_fn: QueryExpr {
-//             selector: "$".to_string(),
-//             query: QueryRequest::Wasm(WasmQuery::Smart {
-//                 contract_addr: "contract_addr".to_string(),
-//                 msg: Binary::from(r#"{"test":"test"}"#.as_bytes()),
-//             }),
-//         },
-//         value: None,
-//         reinitialize: false,
-//         update_fn: None,
-//         encode: true,
-//     });
+    let var4 = Variable::Static(StaticVariable {
+        kind: VariableKind::String,
+        name: "var4".to_string(),
+        encode: false,
+        value: None,
+        init_fn: FnValue::String(StringValue::Ref("$warp.variable.var5".to_string())),
+        reinitialize: false,
+        update_fn: None,
+    });
 
-//     let var1 = Variable::Query(QueryVariable {
-//         name: "var1".to_string(),
-//         kind: VariableKind::Json,
-//         init_fn: QueryExpr {
-//             selector: "$".to_string(),
-//             query: QueryRequest::Wasm(WasmQuery::Smart {
-//                 contract_addr: "contract_addr".to_string(),
-//                 msg: Binary::from(r#"{"test":"$warp.variable.var3"}"#.as_bytes()),
-//             }),
-//         },
-//         value: None,
-//         reinitialize: false,
-//         update_fn: None,
-//         encode: true,
-//     });
+    let var3 = Variable::Query(QueryVariable {
+        name: "var3".to_string(),
+        kind: VariableKind::Json,
+        init_fn: QueryExpr {
+            selector: "$".to_string(),
+            query: QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: "contract_addr".to_string(),
+                msg: Binary::from(r#"{"test":"test"}"#.as_bytes()),
+            }),
+        },
+        value: None,
+        reinitialize: false,
+        update_fn: None,
+        encode: true,
+    });
 
-//     let var2 = Variable::Query(QueryVariable {
-//         name: "var2".to_string(),
-//         kind: VariableKind::Json,
-//         init_fn: QueryExpr {
-//             selector: "$".to_string(),
-//             query: QueryRequest::Wasm(WasmQuery::Smart {
-//                 contract_addr: "$warp.variable.var4".to_string(),
-//                 msg: Binary::from(r#"{"test":"$warp.variable.var1"}"#.as_bytes()),
-//             }),
-//         },
-//         value: None,
-//         reinitialize: false,
-//         update_fn: None,
-//         encode: false,
-//     });
+    let var1 = Variable::Query(QueryVariable {
+        name: "var1".to_string(),
+        kind: VariableKind::Json,
+        init_fn: QueryExpr {
+            selector: "$".to_string(),
+            query: QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: "contract_addr".to_string(),
+                msg: Binary::from(r#"{"test":"$warp.variable.var3"}"#.as_bytes()),
+            }),
+        },
+        value: None,
+        reinitialize: false,
+        update_fn: None,
+        encode: true,
+    });
 
-//     let vars = vec![var5, var4, var3, var1, var2];
-//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+    let var2 = Variable::Query(QueryVariable {
+        name: "var2".to_string(),
+        kind: VariableKind::Json,
+        init_fn: QueryExpr {
+            selector: "$".to_string(),
+            query: QueryRequest::Wasm(WasmQuery::Smart {
+                contract_addr: "$warp.variable.var4".to_string(),
+                msg: Binary::from(r#"{"test":"$warp.variable.var1"}"#.as_bytes()),
+            }),
+        },
+        value: None,
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
 
-//     assert_eq!(
-//         hydrated_vars[4],
-//         Variable::Query(QueryVariable {
-//             name: "var2".to_string(),
-//             kind: VariableKind::Json,
-//             init_fn: QueryExpr {
-//                 selector: "$".to_string(),
-//                 query: QueryRequest::Wasm(WasmQuery::Smart {
-//                     contract_addr: "contract_addr".to_string(),
-//                     msg: Binary::from(
-//                         r#"{"test":"eyJhZGRyZXNzIjoiY29udHJhY3RfYWRkciIsIm1zZyI6Ik1vY2sgbWVzc2FnZSJ9"}"#.as_bytes()
-//                     ),
-//                 }),
-//             },
-//             value: Some(r#"{"address":"contract_addr","msg":"Mock message"}"#.to_string()),
-//             reinitialize: false,
-//             update_fn: None,
-//             encode: false,
-//         })
-//     );
-// }
+    let vars = vec![var5, var4, var3, var1, var2];
+    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None, None).unwrap();
 
-// #[test]
-// fn test_hydrate_vars_nested_variables_binary() {
-//     let deps = mock_dependencies();
-//     let env = mock_env();
+    assert_eq!(
+        hydrated_vars[4],
+        Variable::Query(QueryVariable {
+            name: "var2".to_string(),
+            kind: VariableKind::Json,
+            init_fn: QueryExpr {
+                selector: "$".to_string(),
+                query: QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr: "contract_addr".to_string(),
+                    msg: Binary::from(
+                        r#"{"test":"eyJhZGRyZXNzIjoiY29udHJhY3RfYWRkciIsIm1zZyI6Ik1vY2sgbWVzc2FnZSJ9"}"#.as_bytes()
+                    ),
+                }),
+            },
+            value: Some(r#"{"address":"contract_addr","msg":"Mock message"}"#.to_string()),
+            reinitialize: false,
+            update_fn: None,
+            encode: false,
+        })
+    );
+}
 
-//     let var1 = Variable::Static(StaticVariable {
-//         name: "var1".to_string(),
-//         kind: VariableKind::String,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Simple("static_value".to_string())),
-//         update_fn: None,
-//         encode: false,
-//     });
+#[test]
+fn test_hydrate_vars_nested_variables_binary() {
+    let deps = mock_dependencies();
+    let env = mock_env();
 
-//     let init_fn = QueryExpr {
-//         selector: "$".to_string(),
-//         query: QueryRequest::Wasm(WasmQuery::Smart {
-//             contract_addr: "$warp.variable.var1".to_string(),
-//             msg: Binary::from(r#"{"test": "$warp.variable.var1"}"#.as_bytes()),
-//         }),
-//     };
+    let var1 = Variable::Static(StaticVariable {
+        name: "var1".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple("static_value".to_string())),
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
 
-//     let var2 = Variable::Query(QueryVariable {
-//         name: "var2".to_string(),
-//         kind: VariableKind::String,
-//         init_fn,
-//         value: None,
-//         reinitialize: false,
-//         update_fn: None,
-//         encode: false,
-//     });
+    let init_fn = QueryExpr {
+        selector: "$".to_string(),
+        query: QueryRequest::Wasm(WasmQuery::Smart {
+            contract_addr: "$warp.variable.var1".to_string(),
+            msg: Binary::from(r#"{"test": "$warp.variable.var1"}"#.as_bytes()),
+        }),
+    };
 
-//     let vars = vec![var1, var2];
-//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+    let var2 = Variable::Query(QueryVariable {
+        name: "var2".to_string(),
+        kind: VariableKind::String,
+        init_fn,
+        value: None,
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
 
-//     assert_eq!(
-//         hydrated_vars[1],
-//         Variable::Query(QueryVariable {
-//             name: "var2".to_string(),
-//             kind: VariableKind::String,
-//             init_fn: QueryExpr {
-//                 selector: "$".to_string(),
-//                 query: QueryRequest::Wasm(WasmQuery::Smart {
-//                     contract_addr: "static_value".to_string(),
-//                     msg: Binary::from(r#"{"test": "static_value"}"#.as_bytes()),
-//                 }),
-//             },
-//             value: Some(r#"{"address":"static_value","msg":"Mock message"}"#.to_string()),
-//             reinitialize: false,
-//             update_fn: None,
-//             encode: false,
-//         })
-//     );
-// }
-// #[test]
-// fn test_hydrate_vars_nested_variables_non_binary() {
-//     let deps = mock_dependencies();
-//     let env = mock_env();
+    let vars = vec![var1, var2];
+    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None, None).unwrap();
 
-//     let var1 = Variable::Static(StaticVariable {
-//         name: "var1".to_string(),
-//         kind: VariableKind::String,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Simple("static_value".to_string())),
-//         update_fn: None,
-//         encode: false,
-//     });
+    assert_eq!(
+        hydrated_vars[1],
+        Variable::Query(QueryVariable {
+            name: "var2".to_string(),
+            kind: VariableKind::String,
+            init_fn: QueryExpr {
+                selector: "$".to_string(),
+                query: QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr: "static_value".to_string(),
+                    msg: Binary::from(r#"{"test": "static_value"}"#.as_bytes()),
+                }),
+            },
+            value: Some(r#"{"address":"static_value","msg":"Mock message"}"#.to_string()),
+            reinitialize: false,
+            update_fn: None,
+            encode: false,
+        })
+    );
+}
+#[test]
+fn test_hydrate_vars_nested_variables_non_binary() {
+    let deps = mock_dependencies();
+    let env = mock_env();
 
-//     let init_fn = QueryExpr {
-//         selector: "$".to_string(),
-//         query: QueryRequest::Bank(BankQuery::Balance {
-//             address: "$warp.variable.var1".to_string(),
-//             denom: "denom".to_string(),
-//         }),
-//     };
+    let var1 = Variable::Static(StaticVariable {
+        name: "var1".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple("static_value".to_string())),
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
 
-//     let var2 = Variable::Query(QueryVariable {
-//         name: "var2".to_string(),
-//         kind: VariableKind::String,
-//         init_fn,
-//         value: None,
-//         reinitialize: false,
-//         update_fn: None,
-//         encode: false,
-//     });
+    let init_fn = QueryExpr {
+        selector: "$".to_string(),
+        query: QueryRequest::Bank(BankQuery::Balance {
+            address: "$warp.variable.var1".to_string(),
+            denom: "denom".to_string(),
+        }),
+    };
 
-//     let vars = vec![var1, var2];
-//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+    let var2 = Variable::Query(QueryVariable {
+        name: "var2".to_string(),
+        kind: VariableKind::String,
+        init_fn,
+        value: None,
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
 
-//     assert_eq!(
-//         hydrated_vars[1],
-//         Variable::Query(QueryVariable {
-//             name: "var2".to_string(),
-//             kind: VariableKind::String,
-//             init_fn: QueryExpr {
-//                 selector: "$".to_string(),
-//                 query: QueryRequest::Bank(BankQuery::Balance {
-//                     address: "static_value".to_string(),
-//                     denom: "denom".to_string(),
-//                 }),
-//             },
-//             value: Some("static_value".to_string()),
-//             reinitialize: false,
-//             update_fn: None,
-//             encode: false,
-//         })
-//     );
-// }
+    let vars = vec![var1, var2];
+    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None, None).unwrap();
 
-// #[test]
-// fn test_hydrate_static_nested_vars_and_hydrate_msgs() {
-//     let deps = mock_dependencies();
-//     let env = mock_env();
+    assert_eq!(
+        hydrated_vars[1],
+        Variable::Query(QueryVariable {
+            name: "var2".to_string(),
+            kind: VariableKind::String,
+            init_fn: QueryExpr {
+                selector: "$".to_string(),
+                query: QueryRequest::Bank(BankQuery::Balance {
+                    address: "static_value".to_string(),
+                    denom: "denom".to_string(),
+                }),
+            },
+            value: Some("static_value".to_string()),
+            reinitialize: false,
+            update_fn: None,
+            encode: false,
+        })
+    );
+}
 
-//     let var1 = Variable::Static(StaticVariable {
-//         name: "var1".to_string(),
-//         kind: VariableKind::String,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Simple("static_value_1".to_string())),
-//         update_fn: None,
-//         encode: false,
-//     });
+#[test]
+fn test_hydrate_static_nested_vars_and_hydrate_msgs() {
+    let deps = mock_dependencies();
+    let env = mock_env();
 
-//     #[cw_serde]
-//     struct TestStruct {
-//         test: String,
-//     }
+    let var1 = Variable::Static(StaticVariable {
+        name: "var1".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple("static_value_1".to_string())),
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
 
-//     // ============ TEST HYDRATED VALUE  ============
+    // ============ TEST HYDRATED VALUE  ============
 
-//     let test_msg = TestStruct {
-//         test: format!("$warp.variable.{}", "var1"),
-//     };
+    let test_msg = TestStruct {
+        test: format!("$warp.variable.{}", "var1"),
+    };
 
-//     let json_str = serde_json_wasm::to_string(&test_msg).unwrap();
+    let json_str = serde_json_wasm::to_string(&test_msg).unwrap();
 
-//     let raw_str = r#"{"test":"static_value_1"}"#.to_string();
+    let raw_str = r#"{"test":"static_value_1"}"#.to_string();
 
-//     let var2 = Variable::Static(StaticVariable {
-//         name: "var2".to_string(),
-//         kind: VariableKind::String,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Simple(json_str.clone())),
-//         update_fn: None,
-//         // when encode is false, value will not be base64 encoded after msgs hydration
-//         encode: false,
-//     });
+    let var2 = Variable::Static(StaticVariable {
+        name: "var2".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple(json_str.clone())),
+        reinitialize: false,
+        update_fn: None,
+        // when encode is false, value will not be base64 encoded after msgs hydration
+        encode: false,
+    });
 
-//     let vars = vec![var1.clone(), var2];
-//     let hydrated_vars = hydrate_vars(deps.as_ref(), env.clone(), vars, None).unwrap();
-//     let hydrated_var1 = hydrated_vars[0].clone();
-//     let hydrated_var2 = hydrated_vars[1].clone();
-//     match hydrated_var2.clone() {
-//         Variable::Static(static_var) => {
-//             // var3.encode = false doesn't matter here, it only matters when injecting to msgs during msg hydration
-//             assert_eq!(
-//                 String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
-//                 raw_str
-//             )
-//         }
-//         _ => panic!("Expected static variable"),
-//     };
+    let vars = vec![var1.clone(), var2];
+    let hydrated_vars = hydrate_vars(deps.as_ref(), env.clone(), vars, None, None).unwrap();
+    let hydrated_var1 = hydrated_vars[0].clone();
+    let hydrated_var2 = hydrated_vars[1].clone();
+    match hydrated_var2.clone() {
+        Variable::Static(static_var) => {
+            // var3.encode = false doesn't matter here, it only matters when injecting to msgs during msg hydration
+            assert_eq!(
+                String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
+                raw_str
+            )
+        }
+        _ => panic!("Expected static variable"),
+    };
 
-//     let var3 = Variable::Static(StaticVariable {
-//         name: "var3".to_string(),
-//         kind: VariableKind::String,
-//         value: None,
-//         init_fn: InitFnValue::String(StringValue::Simple(json_str.clone())),
-//         update_fn: None,
-//         // when encode is true, value will be base64 encoded after msgs hydration
-//         encode: true,
-//     });
+    let var3 = Variable::Static(StaticVariable {
+        name: "var3".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple(json_str.clone())),
+        reinitialize: false,
+        update_fn: None,
+        // when encode is true, value will be base64 encoded after msgs hydration
+        encode: true,
+    });
 
-//     let vars = vec![var1, var3];
-//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
-//     let hydrated_var3 = hydrated_vars[1].clone();
-//     match hydrated_var3.clone() {
-//         Variable::Static(static_var) => {
-//             // var3.encode = true doesn't matter here, it only matters when injecting to msgs during msg hydration
-//             assert_eq!(
-//                 String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
-//                 raw_str
-//             );
-//         }
-//         _ => panic!("Expected static variable"),
-//     };
+    let vars = vec![var1, var3];
+    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None, None).unwrap();
+    let hydrated_var3 = hydrated_vars[1].clone();
+    match hydrated_var3.clone() {
+        Variable::Static(static_var) => {
+            // var3.encode = true doesn't matter here, it only matters when injecting to msgs during msg hydration
+            assert_eq!(
+                String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
+                raw_str
+            );
+        }
+        _ => panic!("Expected static variable"),
+    };
 
-//     // ============ TEST HYDRATED MSG AND VAR VALUE SHOULD BE ENCODED ACCORDINGLY ============
+    // ============ TEST HYDRATED MSG AND VAR VALUE SHOULD BE ENCODED ACCORDINGLY ============
 
-//     let encoded_val = base64::encode(raw_str.clone());
-//     assert_eq!(encoded_val, "eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==");
-//     let msgs =
-//         r#"[{"wasm":{"execute":{"contract_addr":"$warp.variable.var1","msg":"eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==","funds":[]}}},
-//         {"wasm":{"execute":{"contract_addr":"$warp.variable.var3","msg":"$warp.variable.var3","funds":[]}}}]"#
-//             .to_string();
+    let encoded_val = base64::encode(raw_str.clone());
+    assert_eq!(encoded_val, "eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==");
+    let msgs =
+        r#"[{"wasm":{"execute":{"contract_addr":"$warp.variable.var1","msg":"eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==","funds":[]}}},
+        {"wasm":{"execute":{"contract_addr":"$warp.variable.var3","msg":"$warp.variable.var3","funds":[]}}}]"#
+            .to_string();
 
-//     let hydrated_msgs =
-//         hydrate_msgs(msgs, vec![hydrated_var1, hydrated_var2, hydrated_var3]).unwrap();
+    let hydrated_msgs =
+        hydrate_msgs(msgs, vec![hydrated_var1, hydrated_var2, hydrated_var3]).unwrap();
 
-//     assert_eq!(
-//         hydrated_msgs[0],
-//         CosmosMsg::Wasm(WasmMsg::Execute {
-//             // Because var1.encode = false, contract_addr should use the plain text value
-//             contract_addr: "static_value_1".to_string(),
-//             msg: Binary::from(raw_str.as_bytes()),
-//             funds: vec![]
-//         })
-//     );
+    assert_eq!(
+        hydrated_msgs[0],
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            // Because var1.encode = false, contract_addr should use the plain text value
+            contract_addr: "static_value_1".to_string(),
+            msg: Binary::from(raw_str.as_bytes()),
+            funds: vec![]
+        })
+    );
 
-//     assert_eq!(
-//         hydrated_msgs[1],
-//         CosmosMsg::Wasm(WasmMsg::Execute {
-//             // Because var3.encode = true, contract_addr should use the encoded value
-//             contract_addr: encoded_val,
-//             // msg is not Binary::from(encoded_val.as_bytes()) appears to be a cosmos msg thing, not a warp thing
-//             msg: Binary::from(raw_str.as_bytes()),
-//             funds: vec![]
-//         })
-//     )
-// }
+    assert_eq!(
+        hydrated_msgs[1],
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            // Because var3.encode = true, contract_addr should use the encoded value
+            contract_addr: encoded_val,
+            // msg is not Binary::from(encoded_val.as_bytes()) appears to be a cosmos msg thing, not a warp thing
+            msg: Binary::from(raw_str.as_bytes()),
+            funds: vec![]
+        })
+    )
+}
 
-// #[test]
-// fn test_test() {
-//     println! {"{}", "[\"{\\\"wasm\\\":{\\\"execute\\\":{\\\"contract_addr\\\":\\\"terra1na348k6rvwxje9jj6ftpsapfeyaejxjeq6tuzdmzysps20l6z23smnlv64\\\",\\\"msg\\\":\\\"eyJleGVjdXRlX3N3YXBfb3BlcmF0aW9ucyI6eyJtYXhfc3ByZWFkIjoiMC4xNSIsIm9wZXJhdGlvbnMiOlt7ImFzdHJvX3N3YXAiOnsib2ZmZXJfYXNzZXRfaW5mbyI6eyJuYXRpdmVfdG9rZW4iOnsiZGVub20iOiJ1bHVuYSJ9fSwiYXNrX2Fzc2V0X2luZm8iOnsidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMXhndnA2cDBxbWw1M3JlcWR5eGdjbDh0dGwwcGtoMG4ybXR4Mm43dHpmYWhuNmUwdmNhN3MwZzdzZzYifX19fSx7ImFzdHJvX3N3YXAiOnsib2ZmZXJfYXNzZXRfaW5mbyI6eyJ0b2tlbiI6eyJjb250cmFjdF9hZGRyIjoidGVycmExeGd2cDZwMHFtbDUzcmVxZHl4Z2NsOHR0bDBwa2gwbjJtdHgybjd0emZhaG42ZTB2Y2E3czBnN3NnNiJ9fSwiYXNrX2Fzc2V0X2luZm8iOnsidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMTY3ZHNxa2gyYWx1cng5OTd3bXljdzl5ZGt5dTU0Z3lzd2UzeWdtcnM0bHd1bWUzdm13a3M4cnVxbnYifX19fV0sIm1pbmltdW1fcmVjZWl2ZSI6IjIzNTM2NjEifX0=\\\",\\\"funds\\\":[{\\\"denom\\\":\\\"uluna\\\",\\\"amount\\\":\\\"10000\\\"}]}}}\"]".replace("\\\\", "")}
-// }
+#[test]
+fn test_hydrate_static_env_vars_and_hydrate_msgs() {
+    let deps = mock_dependencies();
+    let env = mock_env();
+
+    let dummy_warp_account_addr = "terra1".to_string();
+
+    let json_str = serde_json_wasm::to_string(&TestStruct {
+        test: format!("$warp.variable.{}", "var1"),
+    })
+    .unwrap();
+
+    let raw_str = r#"{"test":"static_value_1"}"#.to_string();
+
+    let encoded_val = base64::encode(raw_str.clone());
+    assert_eq!(encoded_val, "eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==");
+
+    // ============ TEST HYDRATED VALUE  ============
+
+    let var1 = Variable::Static(StaticVariable {
+        name: "var1".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple("static_value_1".to_string())),
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
+
+    let var2 = Variable::Static(StaticVariable {
+        name: "var2".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Simple(json_str.clone())),
+        reinitialize: false,
+        update_fn: None,
+        encode: true,
+    });
+
+    let var3 = Variable::Static(StaticVariable {
+        name: "var3".to_string(),
+        kind: VariableKind::String,
+        value: None,
+        init_fn: FnValue::String(StringValue::Env(StringEnvValue::WarpAccountAddr)),
+        reinitialize: false,
+        update_fn: None,
+        encode: false,
+    });
+
+    let vars = vec![var1, var2, var3];
+    let hydrated_vars = hydrate_vars(
+        deps.as_ref(),
+        env,
+        vars,
+        None,
+        Some(dummy_warp_account_addr.clone()),
+    )
+    .unwrap();
+
+    let hydrated_var1 = hydrated_vars[0].clone();
+    let hydrated_var2 = hydrated_vars[1].clone();
+    match hydrated_var2.clone() {
+        Variable::Static(static_var) => {
+            assert_eq!(
+                String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
+                raw_str
+            )
+        }
+        _ => panic!("Expected static variable"),
+    };
+    let hydrated_var3 = hydrated_vars[2].clone();
+    match hydrated_var3.clone() {
+        Variable::Static(static_var) => {
+            assert_eq!(
+                String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
+                dummy_warp_account_addr.clone()
+            )
+        }
+        _ => panic!("Expected static variable"),
+    };
+
+    // ============ TEST HYDRATED MSG AND VAR VALUE SHOULD BE ENCODED ACCORDINGLY ============
+
+    let msgs =
+        r#"[
+            {"wasm":{"execute":{"contract_addr":"$warp.variable.var1","msg":"eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==","funds":[]}}},
+            {"wasm":{"execute":{"contract_addr":"$warp.variable.var3","msg":"$warp.variable.var2","funds":[]}}}
+        ]"#
+            .to_string();
+
+    let hydrated_msgs =
+        hydrate_msgs(msgs, vec![hydrated_var1, hydrated_var2, hydrated_var3]).unwrap();
+
+    assert_eq!(
+        hydrated_msgs[0],
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: "static_value_1".to_string(),
+            msg: Binary::from(raw_str.as_bytes()),
+            funds: vec![]
+        })
+    );
+
+    assert_eq!(
+        hydrated_msgs[1],
+        CosmosMsg::Wasm(WasmMsg::Execute {
+            contract_addr: dummy_warp_account_addr,
+            msg: Binary::from(raw_str.as_bytes()),
+            funds: vec![]
+        })
+    )
+}

--- a/contracts/warp-resolver/src/tests.rs
+++ b/contracts/warp-resolver/src/tests.rs
@@ -1,429 +1,444 @@
-use schemars::_serde_json::json;
+// use schemars::_serde_json::json;
 
-use crate::util::variable::{hydrate_msgs, hydrate_vars};
+// use crate::util::variable::{hydrate_msgs, hydrate_vars};
 
-use cosmwasm_std::{testing::mock_env, WasmQuery};
-use cosmwasm_std::{to_binary, BankQuery, Binary, ContractResult, CosmosMsg, OwnedDeps, WasmMsg};
+// use cosmwasm_std::{testing::mock_env, WasmQuery};
+// use cosmwasm_std::{to_binary, BankQuery, Binary, ContractResult, CosmosMsg, OwnedDeps, WasmMsg};
 
-use crate::contract::query;
-use cosmwasm_schema::cw_serde;
-use cosmwasm_std::testing::{mock_info, MockApi, MockQuerier, MockStorage};
-use cosmwasm_std::{from_slice, Empty, Querier, QueryRequest, SystemError, SystemResult};
+// use crate::contract::query;
+// use cosmwasm_schema::cw_serde;
+// use cosmwasm_std::testing::{mock_info, MockApi, MockQuerier, MockStorage};
+// use cosmwasm_std::{from_slice, Empty, Querier, QueryRequest, SystemError, SystemResult};
 
-use resolver::variable::{QueryExpr, QueryVariable, StaticVariable, Variable, VariableKind};
-use resolver::{QueryMsg, QueryValidateJobCreationMsg};
-use std::marker::PhantomData;
+// use resolver::variable::{
+//     InitFnValue, QueryExpr, QueryVariable, StaticVariable, StringValue, Variable, VariableKind,
+// };
+// use resolver::{QueryMsg, QueryValidateJobCreationMsg};
+// use std::marker::PhantomData;
 
-#[test]
-fn test() {
-    let deps = mock_dependencies();
-    let _info = mock_info("vlad", &[]);
-    let env = mock_env();
-    let msg = QueryValidateJobCreationMsg {
-        condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
-        terminate_condition: None,
-        vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
-        msgs: "[{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}]".to_string(),
-    };
-    let obj = serde_json_wasm::to_string(&vec!["{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}"]).unwrap();
+// #[test]
+// fn test() {
+//     let deps = mock_dependencies();
+//     let _info = mock_info("vlad", &[]);
+//     let env = mock_env();
+//     let msg = QueryValidateJobCreationMsg {
+//         condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
+//         terminate_condition: None,
+//         vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
+//         msgs: "[{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}]".to_string(),
+//     };
+//     let obj = serde_json_wasm::to_string(&vec!["{\"wasm\":{\"execute\":{\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\",\"msg\":\"eyJzd2FwIjp7Im9mZmVyX2Fzc2V0Ijp7ImluZm8iOnsibmF0aXZlX3Rva2VuIjp7ImRlbm9tIjoiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQifX0sImFtb3VudCI6IjEwMDAwMDAifSwibWF4X3NwcmVhZCI6IjAuNSIsImJlbGllZl9wcmljZSI6IjAuNjEwMzg3MzI3MzgyNDYzODE2In19\",\"funds\":[{\"denom\":\"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4\",\"amount\":\"1000000\"}]}}}"]).unwrap();
 
-    let _msg1 = QueryValidateJobCreationMsg {
-        condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
-        terminate_condition: None,
-        vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
-        msgs: obj.clone(),
-    };
+//     let _msg1 = QueryValidateJobCreationMsg {
+//         condition: "{\"expr\":{\"decimal\":{\"op\":\"gte\",\"left\":{\"ref\":\"$warp.variable.return_amount\"},\"right\":{\"simple\":\"620000\"}}}}".parse().unwrap(),
+//         terminate_condition: None,
+//         vars: "[{\"query\":{\"kind\":\"decimal\",\"name\":\"return_amount\",\"init_fn\":{\"query\":{\"wasm\":{\"smart\":{\"msg\":\"eyJzaW11bGF0aW9uIjp7Im9mZmVyX2Fzc2V0Ijp7ImFtb3VudCI6IjEwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6ImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0In19fX19\",\"contract_addr\":\"terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr\"}}},\"selector\":\"$.return_amount\"},\"reinitialize\":false,\"encode\":false}}]".to_string(),
+//         msgs: obj.clone(),
+//     };
 
-    println!("{}", serde_json_wasm::to_string(&obj).unwrap());
+//     println!("{}", serde_json_wasm::to_string(&obj).unwrap());
 
-    let test = query(deps.as_ref(), env, QueryMsg::QueryValidateJobCreation(msg)).unwrap();
-    println!("{}", test)
-}
+//     let test = query(deps.as_ref(), env, QueryMsg::QueryValidateJobCreation(msg)).unwrap();
+//     println!("{}", test)
+// }
 
-#[test]
-fn test_vars() {
-    let test_msg = "{\"execute\":{\"test\":\"$WARPVAR.test\"}}".to_string();
+// #[test]
+// fn test_vars() {
+//     let test_msg = "{\"execute\":{\"test\":\"$WARPVAR.test\"}}".to_string();
 
-    let _idx = test_msg.find("\"$WARPVAR\"");
+//     let _idx = test_msg.find("\"$WARPVAR\"");
 
-    let _new_str = test_msg.replace("\"$WARPVAR.test\"", "\"input\"");
-}
+//     let _new_str = test_msg.replace("\"$WARPVAR.test\"", "\"input\"");
+// }
 
-pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
-    let custom_querier: WasmMockQuerier = WasmMockQuerier::new(MockQuerier::new(&[]));
+// pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+//     let custom_querier: WasmMockQuerier = WasmMockQuerier::new(MockQuerier::new(&[]));
 
-    OwnedDeps {
-        api: MockApi::default(),
-        storage: MockStorage::default(),
-        querier: custom_querier,
-        custom_query_type: PhantomData,
-    }
-}
+//     OwnedDeps {
+//         api: MockApi::default(),
+//         storage: MockStorage::default(),
+//         querier: custom_querier,
+//         custom_query_type: PhantomData,
+//     }
+// }
 
-pub struct WasmMockQuerier {
-    base: MockQuerier<Empty>,
-}
+// pub struct WasmMockQuerier {
+//     base: MockQuerier<Empty>,
+// }
 
-impl Querier for WasmMockQuerier {
-    fn raw_query(&self, bin_request: &[u8]) -> SystemResult<ContractResult<Binary>> {
-        let request: QueryRequest<Empty> = match from_slice(bin_request) {
-            Ok(v) => v,
-            Err(e) => {
-                return SystemResult::Err(SystemError::InvalidRequest {
-                    error: format!("Parsing query request: {}", e),
-                    request: bin_request.into(),
-                });
-            }
-        };
-        self.handle_query(&request)
-    }
-}
+// impl Querier for WasmMockQuerier {
+//     fn raw_query(&self, bin_request: &[u8]) -> SystemResult<ContractResult<Binary>> {
+//         let request: QueryRequest<Empty> = match from_slice(bin_request) {
+//             Ok(v) => v,
+//             Err(e) => {
+//                 return SystemResult::Err(SystemError::InvalidRequest {
+//                     error: format!("Parsing query request: {}", e),
+//                     request: bin_request.into(),
+//                 });
+//             }
+//         };
+//         self.handle_query(&request)
+//     }
+// }
 
-impl WasmMockQuerier {
-    pub fn handle_query(
-        &self,
-        request: &QueryRequest<Empty>,
-    ) -> SystemResult<ContractResult<Binary>> {
-        match &request {
-            QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr,
-                msg: _,
-            }) => {
-                // Mock logic for the Wasm::Smart case
-                // Here for simplicity, we return the contract_addr and msg as is.
+// impl WasmMockQuerier {
+//     pub fn handle_query(
+//         &self,
+//         request: &QueryRequest<Empty>,
+//     ) -> SystemResult<ContractResult<Binary>> {
+//         match &request {
+//             QueryRequest::Wasm(WasmQuery::Smart {
+//                 contract_addr,
+//                 msg: _,
+//             }) => {
+//                 // Mock logic for the Wasm::Smart case
+//                 // Here for simplicity, we return the contract_addr and msg as is.
 
-                // Mock logic for the Wasm::Smart case
-                // Here we return a JSON object with "address" and "msg" fields.
-                let response: String = json!({
-                    "address": contract_addr,
-                    "msg": "Mock message"
-                })
-                .to_string();
+//                 // Mock logic for the Wasm::Smart case
+//                 // Here we return a JSON object with "address" and "msg" fields.
+//                 let response: String = json!({
+//                     "address": contract_addr,
+//                     "msg": "Mock message"
+//                 })
+//                 .to_string();
 
-                SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
-            }
-            QueryRequest::Bank(BankQuery::Balance {
-                address: contract_addr,
-                denom: _,
-            }) => SystemResult::Ok(ContractResult::Ok(
-                to_binary(&contract_addr.to_string()).unwrap(),
-            )),
-            _ => self.base.handle_query(request),
-        }
-    }
-}
+//                 SystemResult::Ok(ContractResult::Ok(to_binary(&response).unwrap()))
+//             }
+//             QueryRequest::Bank(BankQuery::Balance {
+//                 address: contract_addr,
+//                 denom: _,
+//             }) => SystemResult::Ok(ContractResult::Ok(
+//                 to_binary(&contract_addr.to_string()).unwrap(),
+//             )),
+//             _ => self.base.handle_query(request),
+//         }
+//     }
+// }
 
-impl WasmMockQuerier {
-    pub fn new(base: MockQuerier<Empty>) -> Self {
-        WasmMockQuerier { base }
-    }
-}
+// impl WasmMockQuerier {
+//     pub fn new(base: MockQuerier<Empty>) -> Self {
+//         WasmMockQuerier { base }
+//     }
+// }
 
-#[test]
-fn test_hydrate_vars_nested_variables_binary_json() {
-    let deps = mock_dependencies();
-    let env = mock_env();
+// #[test]
+// fn test_hydrate_vars_nested_variables_binary_json() {
+//     let deps = mock_dependencies();
+//     let env = mock_env();
 
-    let var5 = Variable::Static(StaticVariable {
-        kind: VariableKind::String,
-        name: "var5".to_string(),
-        encode: false,
-        value: "contract_addr".to_string(),
-        update_fn: None,
-    });
+//     let var5 = Variable::Static(StaticVariable {
+//         kind: VariableKind::String,
+//         name: "var5".to_string(),
+//         encode: false,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Simple("contract_addr".to_string())),
+//         update_fn: None,
+//     });
 
-    let var4 = Variable::Static(StaticVariable {
-        kind: VariableKind::String,
-        name: "var4".to_string(),
-        encode: false,
-        value: "$warp.variable.var5".to_string(),
-        update_fn: None,
-    });
+//     let var4 = Variable::Static(StaticVariable {
+//         kind: VariableKind::String,
+//         name: "var4".to_string(),
+//         encode: false,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Ref("$warp.variable.var5".to_string())),
+//         update_fn: None,
+//     });
 
-    let var3 = Variable::Query(QueryVariable {
-        name: "var3".to_string(),
-        kind: VariableKind::Json,
-        init_fn: QueryExpr {
-            selector: "$".to_string(),
-            query: QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr: "contract_addr".to_string(),
-                msg: Binary::from(r#"{"test":"test"}"#.as_bytes()),
-            }),
-        },
-        value: None,
-        reinitialize: false,
-        update_fn: None,
-        encode: true,
-    });
+//     let var3 = Variable::Query(QueryVariable {
+//         name: "var3".to_string(),
+//         kind: VariableKind::Json,
+//         init_fn: QueryExpr {
+//             selector: "$".to_string(),
+//             query: QueryRequest::Wasm(WasmQuery::Smart {
+//                 contract_addr: "contract_addr".to_string(),
+//                 msg: Binary::from(r#"{"test":"test"}"#.as_bytes()),
+//             }),
+//         },
+//         value: None,
+//         reinitialize: false,
+//         update_fn: None,
+//         encode: true,
+//     });
 
-    let var1 = Variable::Query(QueryVariable {
-        name: "var1".to_string(),
-        kind: VariableKind::Json,
-        init_fn: QueryExpr {
-            selector: "$".to_string(),
-            query: QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr: "contract_addr".to_string(),
-                msg: Binary::from(r#"{"test":"$warp.variable.var3"}"#.as_bytes()),
-            }),
-        },
-        value: None,
-        reinitialize: false,
-        update_fn: None,
-        encode: true,
-    });
+//     let var1 = Variable::Query(QueryVariable {
+//         name: "var1".to_string(),
+//         kind: VariableKind::Json,
+//         init_fn: QueryExpr {
+//             selector: "$".to_string(),
+//             query: QueryRequest::Wasm(WasmQuery::Smart {
+//                 contract_addr: "contract_addr".to_string(),
+//                 msg: Binary::from(r#"{"test":"$warp.variable.var3"}"#.as_bytes()),
+//             }),
+//         },
+//         value: None,
+//         reinitialize: false,
+//         update_fn: None,
+//         encode: true,
+//     });
 
-    let var2 = Variable::Query(QueryVariable {
-        name: "var2".to_string(),
-        kind: VariableKind::Json,
-        init_fn: QueryExpr {
-            selector: "$".to_string(),
-            query: QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr: "$warp.variable.var4".to_string(),
-                msg: Binary::from(r#"{"test":"$warp.variable.var1"}"#.as_bytes()),
-            }),
-        },
-        value: None,
-        reinitialize: false,
-        update_fn: None,
-        encode: false,
-    });
+//     let var2 = Variable::Query(QueryVariable {
+//         name: "var2".to_string(),
+//         kind: VariableKind::Json,
+//         init_fn: QueryExpr {
+//             selector: "$".to_string(),
+//             query: QueryRequest::Wasm(WasmQuery::Smart {
+//                 contract_addr: "$warp.variable.var4".to_string(),
+//                 msg: Binary::from(r#"{"test":"$warp.variable.var1"}"#.as_bytes()),
+//             }),
+//         },
+//         value: None,
+//         reinitialize: false,
+//         update_fn: None,
+//         encode: false,
+//     });
 
-    let vars = vec![var5, var4, var3, var1, var2];
-    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+//     let vars = vec![var5, var4, var3, var1, var2];
+//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
 
-    assert_eq!(
-        hydrated_vars[4],
-        Variable::Query(QueryVariable {
-            name: "var2".to_string(),
-            kind: VariableKind::Json,
-            init_fn: QueryExpr {
-                selector: "$".to_string(),
-                query: QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: "contract_addr".to_string(),
-                    msg: Binary::from(
-                        r#"{"test":"eyJhZGRyZXNzIjoiY29udHJhY3RfYWRkciIsIm1zZyI6Ik1vY2sgbWVzc2FnZSJ9"}"#.as_bytes()
-                    ),
-                }),
-            },
-            value: Some(r#"{"address":"contract_addr","msg":"Mock message"}"#.to_string()),
-            reinitialize: false,
-            update_fn: None,
-            encode: false,
-        })
-    );
-}
+//     assert_eq!(
+//         hydrated_vars[4],
+//         Variable::Query(QueryVariable {
+//             name: "var2".to_string(),
+//             kind: VariableKind::Json,
+//             init_fn: QueryExpr {
+//                 selector: "$".to_string(),
+//                 query: QueryRequest::Wasm(WasmQuery::Smart {
+//                     contract_addr: "contract_addr".to_string(),
+//                     msg: Binary::from(
+//                         r#"{"test":"eyJhZGRyZXNzIjoiY29udHJhY3RfYWRkciIsIm1zZyI6Ik1vY2sgbWVzc2FnZSJ9"}"#.as_bytes()
+//                     ),
+//                 }),
+//             },
+//             value: Some(r#"{"address":"contract_addr","msg":"Mock message"}"#.to_string()),
+//             reinitialize: false,
+//             update_fn: None,
+//             encode: false,
+//         })
+//     );
+// }
 
-#[test]
-fn test_hydrate_vars_nested_variables_binary() {
-    let deps = mock_dependencies();
-    let env = mock_env();
+// #[test]
+// fn test_hydrate_vars_nested_variables_binary() {
+//     let deps = mock_dependencies();
+//     let env = mock_env();
 
-    let var1 = Variable::Static(StaticVariable {
-        name: "var1".to_string(),
-        kind: VariableKind::String,
-        value: "static_value".to_string(),
-        update_fn: None,
-        encode: false,
-    });
+//     let var1 = Variable::Static(StaticVariable {
+//         name: "var1".to_string(),
+//         kind: VariableKind::String,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Simple("static_value".to_string())),
+//         update_fn: None,
+//         encode: false,
+//     });
 
-    let init_fn = QueryExpr {
-        selector: "$".to_string(),
-        query: QueryRequest::Wasm(WasmQuery::Smart {
-            contract_addr: "$warp.variable.var1".to_string(),
-            msg: Binary::from(r#"{"test": "$warp.variable.var1"}"#.as_bytes()),
-        }),
-    };
+//     let init_fn = QueryExpr {
+//         selector: "$".to_string(),
+//         query: QueryRequest::Wasm(WasmQuery::Smart {
+//             contract_addr: "$warp.variable.var1".to_string(),
+//             msg: Binary::from(r#"{"test": "$warp.variable.var1"}"#.as_bytes()),
+//         }),
+//     };
 
-    let var2 = Variable::Query(QueryVariable {
-        name: "var2".to_string(),
-        kind: VariableKind::String,
-        init_fn,
-        value: None,
-        reinitialize: false,
-        update_fn: None,
-        encode: false,
-    });
+//     let var2 = Variable::Query(QueryVariable {
+//         name: "var2".to_string(),
+//         kind: VariableKind::String,
+//         init_fn,
+//         value: None,
+//         reinitialize: false,
+//         update_fn: None,
+//         encode: false,
+//     });
 
-    let vars = vec![var1, var2];
-    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+//     let vars = vec![var1, var2];
+//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
 
-    assert_eq!(
-        hydrated_vars[1],
-        Variable::Query(QueryVariable {
-            name: "var2".to_string(),
-            kind: VariableKind::String,
-            init_fn: QueryExpr {
-                selector: "$".to_string(),
-                query: QueryRequest::Wasm(WasmQuery::Smart {
-                    contract_addr: "static_value".to_string(),
-                    msg: Binary::from(r#"{"test": "static_value"}"#.as_bytes()),
-                }),
-            },
-            value: Some(r#"{"address":"static_value","msg":"Mock message"}"#.to_string()),
-            reinitialize: false,
-            update_fn: None,
-            encode: false,
-        })
-    );
-}
-#[test]
-fn test_hydrate_vars_nested_variables_non_binary() {
-    let deps = mock_dependencies();
-    let env = mock_env();
+//     assert_eq!(
+//         hydrated_vars[1],
+//         Variable::Query(QueryVariable {
+//             name: "var2".to_string(),
+//             kind: VariableKind::String,
+//             init_fn: QueryExpr {
+//                 selector: "$".to_string(),
+//                 query: QueryRequest::Wasm(WasmQuery::Smart {
+//                     contract_addr: "static_value".to_string(),
+//                     msg: Binary::from(r#"{"test": "static_value"}"#.as_bytes()),
+//                 }),
+//             },
+//             value: Some(r#"{"address":"static_value","msg":"Mock message"}"#.to_string()),
+//             reinitialize: false,
+//             update_fn: None,
+//             encode: false,
+//         })
+//     );
+// }
+// #[test]
+// fn test_hydrate_vars_nested_variables_non_binary() {
+//     let deps = mock_dependencies();
+//     let env = mock_env();
 
-    let var1 = Variable::Static(StaticVariable {
-        name: "var1".to_string(),
-        kind: VariableKind::String,
-        value: "static_value".to_string(),
-        update_fn: None,
-        encode: false,
-    });
+//     let var1 = Variable::Static(StaticVariable {
+//         name: "var1".to_string(),
+//         kind: VariableKind::String,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Simple("static_value".to_string())),
+//         update_fn: None,
+//         encode: false,
+//     });
 
-    let init_fn = QueryExpr {
-        selector: "$".to_string(),
-        query: QueryRequest::Bank(BankQuery::Balance {
-            address: "$warp.variable.var1".to_string(),
-            denom: "denom".to_string(),
-        }),
-    };
+//     let init_fn = QueryExpr {
+//         selector: "$".to_string(),
+//         query: QueryRequest::Bank(BankQuery::Balance {
+//             address: "$warp.variable.var1".to_string(),
+//             denom: "denom".to_string(),
+//         }),
+//     };
 
-    let var2 = Variable::Query(QueryVariable {
-        name: "var2".to_string(),
-        kind: VariableKind::String,
-        init_fn,
-        value: None,
-        reinitialize: false,
-        update_fn: None,
-        encode: false,
-    });
+//     let var2 = Variable::Query(QueryVariable {
+//         name: "var2".to_string(),
+//         kind: VariableKind::String,
+//         init_fn,
+//         value: None,
+//         reinitialize: false,
+//         update_fn: None,
+//         encode: false,
+//     });
 
-    let vars = vec![var1, var2];
-    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+//     let vars = vec![var1, var2];
+//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
 
-    assert_eq!(
-        hydrated_vars[1],
-        Variable::Query(QueryVariable {
-            name: "var2".to_string(),
-            kind: VariableKind::String,
-            init_fn: QueryExpr {
-                selector: "$".to_string(),
-                query: QueryRequest::Bank(BankQuery::Balance {
-                    address: "static_value".to_string(),
-                    denom: "denom".to_string(),
-                }),
-            },
-            value: Some("static_value".to_string()),
-            reinitialize: false,
-            update_fn: None,
-            encode: false,
-        })
-    );
-}
+//     assert_eq!(
+//         hydrated_vars[1],
+//         Variable::Query(QueryVariable {
+//             name: "var2".to_string(),
+//             kind: VariableKind::String,
+//             init_fn: QueryExpr {
+//                 selector: "$".to_string(),
+//                 query: QueryRequest::Bank(BankQuery::Balance {
+//                     address: "static_value".to_string(),
+//                     denom: "denom".to_string(),
+//                 }),
+//             },
+//             value: Some("static_value".to_string()),
+//             reinitialize: false,
+//             update_fn: None,
+//             encode: false,
+//         })
+//     );
+// }
 
-#[test]
-fn test_hydrate_static_nested_vars_and_hydrate_msgs() {
-    let deps = mock_dependencies();
-    let env = mock_env();
+// #[test]
+// fn test_hydrate_static_nested_vars_and_hydrate_msgs() {
+//     let deps = mock_dependencies();
+//     let env = mock_env();
 
-    let var1 = Variable::Static(StaticVariable {
-        name: "var1".to_string(),
-        kind: VariableKind::String,
-        value: "static_value_1".to_string(),
-        update_fn: None,
-        encode: false,
-    });
+//     let var1 = Variable::Static(StaticVariable {
+//         name: "var1".to_string(),
+//         kind: VariableKind::String,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Simple("static_value_1".to_string())),
+//         update_fn: None,
+//         encode: false,
+//     });
 
-    #[cw_serde]
-    struct TestStruct {
-        test: String,
-    }
+//     #[cw_serde]
+//     struct TestStruct {
+//         test: String,
+//     }
 
-    // ============ TEST HYDRATED VALUE  ============
+//     // ============ TEST HYDRATED VALUE  ============
 
-    let test_msg = TestStruct {
-        test: format!("$warp.variable.{}", "var1"),
-    };
+//     let test_msg = TestStruct {
+//         test: format!("$warp.variable.{}", "var1"),
+//     };
 
-    let json_str = serde_json_wasm::to_string(&test_msg).unwrap();
+//     let json_str = serde_json_wasm::to_string(&test_msg).unwrap();
 
-    let raw_str = r#"{"test":"static_value_1"}"#.to_string();
+//     let raw_str = r#"{"test":"static_value_1"}"#.to_string();
 
-    let var2 = Variable::Static(StaticVariable {
-        name: "var2".to_string(),
-        kind: VariableKind::String,
-        value: json_str.clone(),
-        update_fn: None,
-        // when encode is false, value will not be base64 encoded after msgs hydration
-        encode: false,
-    });
+//     let var2 = Variable::Static(StaticVariable {
+//         name: "var2".to_string(),
+//         kind: VariableKind::String,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Simple(json_str.clone())),
+//         update_fn: None,
+//         // when encode is false, value will not be base64 encoded after msgs hydration
+//         encode: false,
+//     });
 
-    let vars = vec![var1.clone(), var2];
-    let hydrated_vars = hydrate_vars(deps.as_ref(), env.clone(), vars, None).unwrap();
-    let hydrated_var1 = hydrated_vars[0].clone();
-    let hydrated_var2 = hydrated_vars[1].clone();
-    match hydrated_var2.clone() {
-        Variable::Static(static_var) => {
-            // var3.encode = false doesn't matter here, it only matters when injecting to msgs during msg hydration
-            assert_eq!(String::from_utf8(static_var.value.into()).unwrap(), raw_str)
-        }
-        _ => panic!("Expected static variable"),
-    };
+//     let vars = vec![var1.clone(), var2];
+//     let hydrated_vars = hydrate_vars(deps.as_ref(), env.clone(), vars, None).unwrap();
+//     let hydrated_var1 = hydrated_vars[0].clone();
+//     let hydrated_var2 = hydrated_vars[1].clone();
+//     match hydrated_var2.clone() {
+//         Variable::Static(static_var) => {
+//             // var3.encode = false doesn't matter here, it only matters when injecting to msgs during msg hydration
+//             assert_eq!(
+//                 String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
+//                 raw_str
+//             )
+//         }
+//         _ => panic!("Expected static variable"),
+//     };
 
-    let var3 = Variable::Static(StaticVariable {
-        name: "var3".to_string(),
-        kind: VariableKind::String,
-        value: json_str,
-        update_fn: None,
-        // when encode is true, value will be base64 encoded after msgs hydration
-        encode: true,
-    });
+//     let var3 = Variable::Static(StaticVariable {
+//         name: "var3".to_string(),
+//         kind: VariableKind::String,
+//         value: None,
+//         init_fn: InitFnValue::String(StringValue::Simple(json_str.clone())),
+//         update_fn: None,
+//         // when encode is true, value will be base64 encoded after msgs hydration
+//         encode: true,
+//     });
 
-    let vars = vec![var1, var3];
-    let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
-    let hydrated_var3 = hydrated_vars[1].clone();
-    match hydrated_var3.clone() {
-        Variable::Static(static_var) => {
-            // var3.encode = true doesn't matter here, it only matters when injecting to msgs during msg hydration
-            assert_eq!(String::from_utf8(static_var.value.into()).unwrap(), raw_str);
-        }
-        _ => panic!("Expected static variable"),
-    };
+//     let vars = vec![var1, var3];
+//     let hydrated_vars = hydrate_vars(deps.as_ref(), env, vars, None).unwrap();
+//     let hydrated_var3 = hydrated_vars[1].clone();
+//     match hydrated_var3.clone() {
+//         Variable::Static(static_var) => {
+//             // var3.encode = true doesn't matter here, it only matters when injecting to msgs during msg hydration
+//             assert_eq!(
+//                 String::from_utf8(static_var.value.unwrap_or_default().into()).unwrap(),
+//                 raw_str
+//             );
+//         }
+//         _ => panic!("Expected static variable"),
+//     };
 
-    // ============ TEST HYDRATED MSG AND VAR VALUE SHOULD BE ENCODED ACCORDINGLY ============
+//     // ============ TEST HYDRATED MSG AND VAR VALUE SHOULD BE ENCODED ACCORDINGLY ============
 
-    let encoded_val = base64::encode(raw_str.clone());
-    assert_eq!(encoded_val, "eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==");
-    let msgs =
-        r#"[{"wasm":{"execute":{"contract_addr":"$warp.variable.var1","msg":"eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==","funds":[]}}},
-        {"wasm":{"execute":{"contract_addr":"$warp.variable.var3","msg":"$warp.variable.var3","funds":[]}}}]"#
-            .to_string();
+//     let encoded_val = base64::encode(raw_str.clone());
+//     assert_eq!(encoded_val, "eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==");
+//     let msgs =
+//         r#"[{"wasm":{"execute":{"contract_addr":"$warp.variable.var1","msg":"eyJ0ZXN0Ijoic3RhdGljX3ZhbHVlXzEifQ==","funds":[]}}},
+//         {"wasm":{"execute":{"contract_addr":"$warp.variable.var3","msg":"$warp.variable.var3","funds":[]}}}]"#
+//             .to_string();
 
-    let hydrated_msgs =
-        hydrate_msgs(msgs, vec![hydrated_var1, hydrated_var2, hydrated_var3]).unwrap();
+//     let hydrated_msgs =
+//         hydrate_msgs(msgs, vec![hydrated_var1, hydrated_var2, hydrated_var3]).unwrap();
 
-    assert_eq!(
-        hydrated_msgs[0],
-        CosmosMsg::Wasm(WasmMsg::Execute {
-            // Because var1.encode = false, contract_addr should use the plain text value
-            contract_addr: "static_value_1".to_string(),
-            msg: Binary::from(raw_str.as_bytes()),
-            funds: vec![]
-        })
-    );
+//     assert_eq!(
+//         hydrated_msgs[0],
+//         CosmosMsg::Wasm(WasmMsg::Execute {
+//             // Because var1.encode = false, contract_addr should use the plain text value
+//             contract_addr: "static_value_1".to_string(),
+//             msg: Binary::from(raw_str.as_bytes()),
+//             funds: vec![]
+//         })
+//     );
 
-    assert_eq!(
-        hydrated_msgs[1],
-        CosmosMsg::Wasm(WasmMsg::Execute {
-            // Because var3.encode = true, contract_addr should use the encoded value
-            contract_addr: encoded_val,
-            // msg is not Binary::from(encoded_val.as_bytes()) appears to be a cosmos msg thing, not a warp thing
-            msg: Binary::from(raw_str.as_bytes()),
-            funds: vec![]
-        })
-    )
-}
+//     assert_eq!(
+//         hydrated_msgs[1],
+//         CosmosMsg::Wasm(WasmMsg::Execute {
+//             // Because var3.encode = true, contract_addr should use the encoded value
+//             contract_addr: encoded_val,
+//             // msg is not Binary::from(encoded_val.as_bytes()) appears to be a cosmos msg thing, not a warp thing
+//             msg: Binary::from(raw_str.as_bytes()),
+//             funds: vec![]
+//         })
+//     )
+// }
 
-#[test]
-fn test_test() {
-    println! {"{}", "[\"{\\\"wasm\\\":{\\\"execute\\\":{\\\"contract_addr\\\":\\\"terra1na348k6rvwxje9jj6ftpsapfeyaejxjeq6tuzdmzysps20l6z23smnlv64\\\",\\\"msg\\\":\\\"eyJleGVjdXRlX3N3YXBfb3BlcmF0aW9ucyI6eyJtYXhfc3ByZWFkIjoiMC4xNSIsIm9wZXJhdGlvbnMiOlt7ImFzdHJvX3N3YXAiOnsib2ZmZXJfYXNzZXRfaW5mbyI6eyJuYXRpdmVfdG9rZW4iOnsiZGVub20iOiJ1bHVuYSJ9fSwiYXNrX2Fzc2V0X2luZm8iOnsidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMXhndnA2cDBxbWw1M3JlcWR5eGdjbDh0dGwwcGtoMG4ybXR4Mm43dHpmYWhuNmUwdmNhN3MwZzdzZzYifX19fSx7ImFzdHJvX3N3YXAiOnsib2ZmZXJfYXNzZXRfaW5mbyI6eyJ0b2tlbiI6eyJjb250cmFjdF9hZGRyIjoidGVycmExeGd2cDZwMHFtbDUzcmVxZHl4Z2NsOHR0bDBwa2gwbjJtdHgybjd0emZhaG42ZTB2Y2E3czBnN3NnNiJ9fSwiYXNrX2Fzc2V0X2luZm8iOnsidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMTY3ZHNxa2gyYWx1cng5OTd3bXljdzl5ZGt5dTU0Z3lzd2UzeWdtcnM0bHd1bWUzdm13a3M4cnVxbnYifX19fV0sIm1pbmltdW1fcmVjZWl2ZSI6IjIzNTM2NjEifX0=\\\",\\\"funds\\\":[{\\\"denom\\\":\\\"uluna\\\",\\\"amount\\\":\\\"10000\\\"}]}}}\"]".replace("\\\\", "")}
-}
+// #[test]
+// fn test_test() {
+//     println! {"{}", "[\"{\\\"wasm\\\":{\\\"execute\\\":{\\\"contract_addr\\\":\\\"terra1na348k6rvwxje9jj6ftpsapfeyaejxjeq6tuzdmzysps20l6z23smnlv64\\\",\\\"msg\\\":\\\"eyJleGVjdXRlX3N3YXBfb3BlcmF0aW9ucyI6eyJtYXhfc3ByZWFkIjoiMC4xNSIsIm9wZXJhdGlvbnMiOlt7ImFzdHJvX3N3YXAiOnsib2ZmZXJfYXNzZXRfaW5mbyI6eyJuYXRpdmVfdG9rZW4iOnsiZGVub20iOiJ1bHVuYSJ9fSwiYXNrX2Fzc2V0X2luZm8iOnsidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMXhndnA2cDBxbWw1M3JlcWR5eGdjbDh0dGwwcGtoMG4ybXR4Mm43dHpmYWhuNmUwdmNhN3MwZzdzZzYifX19fSx7ImFzdHJvX3N3YXAiOnsib2ZmZXJfYXNzZXRfaW5mbyI6eyJ0b2tlbiI6eyJjb250cmFjdF9hZGRyIjoidGVycmExeGd2cDZwMHFtbDUzcmVxZHl4Z2NsOHR0bDBwa2gwbjJtdHgybjd0emZhaG42ZTB2Y2E3czBnN3NnNiJ9fSwiYXNrX2Fzc2V0X2luZm8iOnsidG9rZW4iOnsiY29udHJhY3RfYWRkciI6InRlcnJhMTY3ZHNxa2gyYWx1cng5OTd3bXljdzl5ZGt5dTU0Z3lzd2UzeWdtcnM0bHd1bWUzdm13a3M4cnVxbnYifX19fV0sIm1pbmltdW1fcmVjZWl2ZSI6IjIzNTM2NjEifX0=\\\",\\\"funds\\\":[{\\\"denom\\\":\\\"uluna\\\",\\\"amount\\\":\\\"10000\\\"}]}}}\"]".replace("\\\\", "")}
+// }

--- a/contracts/warp-resolver/src/util/condition.rs
+++ b/contracts/warp-resolver/src/util/condition.rs
@@ -316,9 +316,9 @@ pub fn resolve_string_value_env(
     value: StringEnvValue,
     warp_account_addr: Option<String>,
 ) -> Result<String, ContractError> {
-    if warp_account_addr.is_none() {
+    if (warp_account_addr).is_none() {
         return Err(ContractError::HydrationError {
-            msg: format!("Warp account addr not found."),
+            msg: "Warp account addr not found.".to_string(),
         });
     }
     // TODO: add warp_account_addr validation
@@ -337,7 +337,7 @@ pub fn resolve_string_value_asset(
         StringValue::Simple(value) => Ok(value),
         StringValue::Ref(r) => resolve_ref_string(deps, env, r, vars),
         StringValue::Env(value) => Err(ContractError::HydrationError {
-            msg: format!("String Env value not apply to string asset"),
+            msg: format!("String Env value not apply to string asset: {:?}", value),
         }),
     }
 }
@@ -352,7 +352,7 @@ pub fn resolve_string_value_json(
         StringValue::Simple(value) => Ok(value),
         StringValue::Ref(r) => resolve_ref_string(deps, env, r, vars),
         StringValue::Env(value) => Err(ContractError::HydrationError {
-            msg: format!("String Env value not apply to string json"),
+            msg: format!("String Env value not apply to string json: {:?}", value),
         }),
     }
 }

--- a/contracts/warp-resolver/src/util/condition.rs
+++ b/contracts/warp-resolver/src/util/condition.rs
@@ -10,7 +10,7 @@ use json_codec_wasm::Decoder;
 use resolver::condition::{
     BlockExpr, Condition, DecimalFnOp, Expr, GenExpr, IntFnOp, NumEnvValue, NumExprOp,
     NumExprValue, NumFnValue, NumOp, NumValue, StringEnvValue, StringOp, StringValue, TimeExpr,
-    TimeOp, Value,
+    TimeOp,
 };
 use resolver::variable::{QueryExpr, Variable};
 use std::str::FromStr;
@@ -20,11 +20,12 @@ pub fn resolve_cond(
     env: Env,
     cond: Condition,
     vars: &Vec<Variable>,
+    warp_account_addr: Option<String>,
 ) -> Result<bool, ContractError> {
     match cond {
         Condition::And(conds) => {
             for cond in conds {
-                if !resolve_cond(deps, env.clone(), *cond, vars)? {
+                if !resolve_cond(deps, env.clone(), *cond, vars, warp_account_addr.clone())? {
                     return Ok(false);
                 }
             }
@@ -32,14 +33,14 @@ pub fn resolve_cond(
         }
         Condition::Or(conds) => {
             for cond in conds {
-                if resolve_cond(deps, env.clone(), *cond, vars)? {
+                if resolve_cond(deps, env.clone(), *cond, vars, warp_account_addr.clone())? {
                     return Ok(true);
                 }
             }
             Ok(false)
         }
-        Condition::Not(cond) => Ok(!resolve_cond(deps, env, *cond, vars)?),
-        Condition::Expr(expr) => Ok(resolve_expr(deps, env, *expr, vars)?),
+        Condition::Not(cond) => Ok(!resolve_cond(deps, env, *cond, vars, warp_account_addr)?),
+        Condition::Expr(expr) => Ok(resolve_expr(deps, env, *expr, vars, warp_account_addr)?),
     }
 }
 
@@ -48,9 +49,10 @@ pub fn resolve_expr(
     env: Env,
     expr: Expr,
     vars: &Vec<Variable>,
+    warp_account_addr: Option<String>,
 ) -> Result<bool, ContractError> {
     match expr {
-        Expr::String(expr) => resolve_string_expr(deps, env, expr, vars),
+        Expr::String(expr) => resolve_string_expr(deps, env, expr, vars, warp_account_addr),
         Expr::Uint(expr) => resolve_uint_expr(deps, env, expr, vars),
         Expr::Int(expr) => resolve_int_expr(deps, env, expr, vars),
         Expr::Decimal(expr) => resolve_decimal_expr(deps, env, expr, vars),
@@ -298,68 +300,6 @@ pub fn resolve_num_env_uint(
     }
 }
 
-pub fn resolve_string_value(
-    deps: Deps,
-    env: Env,
-    value: StringValue<String>,
-    vars: &Vec<Variable>,
-    warp_account_addr: Option<String>,
-) -> Result<String, ContractError> {
-    match value {
-        StringValue::Simple(value) => Ok(value),
-        StringValue::Ref(r) => resolve_ref_string(deps, env, r, vars),
-        StringValue::Env(value) => resolve_string_value_env(deps, value, warp_account_addr),
-    }
-}
-
-pub fn resolve_string_value_env(
-    deps: Deps,
-    value: StringEnvValue,
-    warp_account_addr: Option<String>,
-) -> Result<String, ContractError> {
-    match value {
-        StringEnvValue::WarpAccountAddr => match warp_account_addr {
-            Some(addr) => {
-                deps.api.addr_validate(&addr)?;
-                Ok(addr)
-            }
-            None => Err(ContractError::HydrationError {
-                msg: "Warp account addr not found.".to_string(),
-            }),
-        },
-    }
-}
-
-pub fn resolve_string_value_asset(
-    deps: Deps,
-    env: Env,
-    value: StringValue<String>,
-    vars: &Vec<Variable>,
-) -> Result<String, ContractError> {
-    match value {
-        StringValue::Simple(value) => Ok(value),
-        StringValue::Ref(r) => resolve_ref_string(deps, env, r, vars),
-        StringValue::Env(value) => Err(ContractError::HydrationError {
-            msg: format!("String Env value not apply to string asset: {:?}", value),
-        }),
-    }
-}
-
-pub fn resolve_string_value_json(
-    deps: Deps,
-    env: Env,
-    value: StringValue<String>,
-    vars: &Vec<Variable>,
-) -> Result<String, ContractError> {
-    match value {
-        StringValue::Simple(value) => Ok(value),
-        StringValue::Ref(r) => resolve_ref_string(deps, env, r, vars),
-        StringValue::Env(value) => Err(ContractError::HydrationError {
-            msg: format!("String Env value not apply to string json: {:?}", value),
-        }),
-    }
-}
-
 pub fn resolve_decimal_expr(
     deps: Deps,
     env: Env,
@@ -555,34 +495,52 @@ pub fn resolve_decimal_op(
 pub fn resolve_string_expr(
     deps: Deps,
     env: Env,
-    expr: GenExpr<Value<String>, StringOp>,
+    expr: GenExpr<StringValue<String>, StringOp>,
     vars: &Vec<Variable>,
+    warp_account_addr: Option<String>,
 ) -> Result<bool, ContractError> {
-    match (expr.left, expr.right) {
-        (Value::Simple(left), Value::Simple(right)) => {
-            Ok(resolve_str_op(deps, env, left, right, expr.op))
-        }
-        (Value::Simple(left), Value::Ref(right)) => Ok(resolve_str_op(
-            deps,
-            env.clone(),
-            left,
-            resolve_ref_string(deps, env, right, vars)?,
-            expr.op,
-        )),
-        (Value::Ref(left), Value::Simple(right)) => Ok(resolve_str_op(
-            deps,
-            env.clone(),
-            resolve_ref_string(deps, env, left, vars)?,
-            right,
-            expr.op,
-        )),
-        (Value::Ref(left), Value::Ref(right)) => Ok(resolve_str_op(
-            deps,
-            env.clone(),
-            resolve_ref_string(deps, env.clone(), left, vars)?,
-            resolve_ref_string(deps, env, right, vars)?,
-            expr.op,
-        )),
+    let left = match expr.left {
+        StringValue::Simple(left) => left,
+        StringValue::Ref(left) => resolve_ref_string(deps, env.clone(), left, vars)?,
+        StringValue::Env(left) => resolve_string_value_env(deps, left, warp_account_addr.clone())?,
+    };
+    let right = match expr.right {
+        StringValue::Simple(right) => right,
+        StringValue::Ref(right) => resolve_ref_string(deps, env.clone(), right, vars)?,
+        StringValue::Env(right) => resolve_string_value_env(deps, right, warp_account_addr)?,
+    };
+    Ok(resolve_str_op(deps, env, left, right, expr.op))
+}
+
+pub fn resolve_string_value(
+    deps: Deps,
+    env: Env,
+    value: StringValue<String>,
+    vars: &Vec<Variable>,
+    warp_account_addr: Option<String>,
+) -> Result<String, ContractError> {
+    match value {
+        StringValue::Simple(value) => Ok(value),
+        StringValue::Ref(r) => resolve_ref_string(deps, env, r, vars),
+        StringValue::Env(value) => resolve_string_value_env(deps, value, warp_account_addr),
+    }
+}
+
+pub fn resolve_string_value_env(
+    deps: Deps,
+    value: StringEnvValue,
+    warp_account_addr: Option<String>,
+) -> Result<String, ContractError> {
+    match value {
+        StringEnvValue::WarpAccountAddr => match warp_account_addr {
+            Some(addr) => {
+                deps.api.addr_validate(&addr)?;
+                Ok(addr)
+            }
+            None => Err(ContractError::HydrationError {
+                msg: "Warp account addr not found.".to_string(),
+            }),
+        },
     }
 }
 

--- a/contracts/warp-resolver/src/util/variable.rs
+++ b/contracts/warp-resolver/src/util/variable.rs
@@ -14,9 +14,7 @@ use std::str::FromStr;
 use controller::job::{ExternalInput, JobStatus};
 use resolver::variable::{FnValue, QueryExpr, Variable, VariableKind};
 
-use super::condition::{
-    resolve_string_value, resolve_string_value_asset, resolve_string_value_json,
-};
+use super::condition::resolve_string_value;
 
 pub fn hydrate_vars(
     deps: Deps,
@@ -150,11 +148,12 @@ pub fn hydrate_vars(
                         VariableKind::Asset => match v.init_fn.clone() {
                             FnValue::String(val) => {
                                 v.value = Some(replace_in_string(
-                                    resolve_string_value_asset(
+                                    resolve_string_value(
                                         deps,
                                         env.clone(),
                                         val,
                                         &hydrated_vars,
+                                        warp_account_addr.clone(),
                                     )?,
                                     &hydrated_vars,
                                 )?)
@@ -169,11 +168,12 @@ pub fn hydrate_vars(
                         VariableKind::Json => match v.init_fn.clone() {
                             FnValue::String(val) => {
                                 v.value = Some(replace_in_string(
-                                    resolve_string_value_json(
+                                    resolve_string_value(
                                         deps,
                                         env.clone(),
                                         val,
                                         &hydrated_vars,
+                                        warp_account_addr.clone(),
                                     )?,
                                     &hydrated_vars,
                                 )?)

--- a/contracts/warp-resolver/src/util/variable.rs
+++ b/contracts/warp-resolver/src/util/variable.rs
@@ -142,7 +142,7 @@ pub fn hydrate_vars(
                             }
                             _ => {
                                 return Err(ContractError::HydrationError {
-                                    msg: "Variable init_fn is not of type FnValue::String."
+                                    msg: "1Variable init_fn is not of type FnValue::String."
                                         .to_string(),
                                 })
                             }
@@ -182,7 +182,7 @@ pub fn hydrate_vars(
                                 return Err(ContractError::HydrationError {
                                     msg: "Variable init_fn is not of type FnValue::String."
                                         .to_string(),
-                                })
+                                });
                             }
                         },
                     }

--- a/contracts/warp-resolver/src/util/variable.rs
+++ b/contracts/warp-resolver/src/util/variable.rs
@@ -32,12 +32,13 @@ pub fn hydrate_vars(
             Variable::Static(mut v) => {
                 if v.reinitialize || v.value.is_none() {
                     match v.kind {
-                        VariableKind::Uint => match v.init_fn {
+                        VariableKind::Uint => match v.init_fn.clone() {
                             FnValue::Uint(val) => {
-                                v.value = Some(
+                                v.value = Some(replace_in_string(
                                     resolve_num_value_uint(deps, env.clone(), val, &hydrated_vars)?
                                         .to_string(),
-                                )
+                                    &hydrated_vars,
+                                )?)
                             }
                             _ => {
                                 return Err(ContractError::HydrationError {
@@ -46,12 +47,13 @@ pub fn hydrate_vars(
                                 })
                             }
                         },
-                        VariableKind::Int => match v.init_fn {
+                        VariableKind::Int => match v.init_fn.clone() {
                             FnValue::Int(val) => {
-                                v.value = Some(
+                                v.value = Some(replace_in_string(
                                     resolve_num_value_int(deps, env.clone(), val, &hydrated_vars)?
                                         .to_string(),
-                                )
+                                    &hydrated_vars,
+                                )?)
                             }
                             _ => {
                                 return Err(ContractError::HydrationError {
@@ -60,9 +62,9 @@ pub fn hydrate_vars(
                                 })
                             }
                         },
-                        VariableKind::Decimal => match v.init_fn {
+                        VariableKind::Decimal => match v.init_fn.clone() {
                             FnValue::Decimal(val) => {
-                                v.value = Some(
+                                v.value = Some(replace_in_string(
                                     resolve_num_value_decimal(
                                         deps,
                                         env.clone(),
@@ -70,7 +72,8 @@ pub fn hydrate_vars(
                                         &hydrated_vars,
                                     )?
                                     .to_string(),
-                                )
+                                    &hydrated_vars,
+                                )?)
                             }
                             _ => {
                                 return Err(ContractError::HydrationError {
@@ -79,57 +82,43 @@ pub fn hydrate_vars(
                                 })
                             }
                         },
-                        VariableKind::Timestamp => {
-                            // v.value = Some(
-                            //     resolve_query_expr_int(deps, env.clone(), v.init_fn.clone())?
-                            //         .to_string(),
-                            // )
-                            match v.init_fn {
-                                FnValue::Timestamp(val) => {
-                                    v.value = Some(
-                                        resolve_num_value_int(
-                                            deps,
-                                            env.clone(),
-                                            val,
-                                            &hydrated_vars,
-                                        )?
+                        VariableKind::Timestamp => match v.init_fn.clone() {
+                            FnValue::Timestamp(val) => {
+                                v.value = Some(replace_in_string(
+                                    resolve_num_value_int(deps, env.clone(), val, &hydrated_vars)?
                                         .to_string(),
-                                    )
-                                }
-                                _ => {
-                                    return Err(ContractError::HydrationError {
-                                        msg: "Variable init_fn is not of type FnValue::Timestamp."
-                                            .to_string(),
-                                    })
-                                }
+                                    &hydrated_vars,
+                                )?)
                             }
-                        }
-                        VariableKind::Bool => {
-                            // v.value = Some(
-                            //     resolve_query_expr_bool(deps, env.clone(), v.init_fn.clone())?
-                            //         .to_string(),
-                            // )
-                            match v.init_fn {
-                                FnValue::Bool(val) => {
-                                    v.value = Some(
-                                        resolve_ref_bool(deps, env.clone(), val, &hydrated_vars)?
-                                            .to_string(),
-                                    )
-                                }
-                                _ => {
-                                    return Err(ContractError::HydrationError {
-                                        msg: "Variable init_fn is not of type FnValue::Bool."
-                                            .to_string(),
-                                    })
-                                }
+                            _ => {
+                                return Err(ContractError::HydrationError {
+                                    msg: "Variable init_fn is not of type FnValue::Timestamp."
+                                        .to_string(),
+                                })
                             }
-                        }
-                        VariableKind::Amount => match v.init_fn {
+                        },
+                        VariableKind::Bool => match v.init_fn.clone() {
+                            FnValue::Bool(val) => {
+                                v.value = Some(replace_in_string(
+                                    resolve_ref_bool(deps, env.clone(), val, &hydrated_vars)?
+                                        .to_string(),
+                                    &hydrated_vars,
+                                )?)
+                            }
+                            _ => {
+                                return Err(ContractError::HydrationError {
+                                    msg: "Variable init_fn is not of type FnValue::Bool."
+                                        .to_string(),
+                                })
+                            }
+                        },
+                        VariableKind::Amount => match v.init_fn.clone() {
                             FnValue::Uint(val) => {
-                                v.value = Some(
+                                v.value = Some(replace_in_string(
                                     resolve_num_value_uint(deps, env.clone(), val, &hydrated_vars)?
                                         .to_string(),
-                                )
+                                    &hydrated_vars,
+                                )?)
                             }
                             _ => {
                                 return Err(ContractError::HydrationError {
@@ -138,29 +127,16 @@ pub fn hydrate_vars(
                                 })
                             }
                         },
-                        VariableKind::String => match v.init_fn {
+                        VariableKind::String => match v.init_fn.clone() {
                             FnValue::String(val) => {
-                                v.value = Some(resolve_string_value(
-                                    deps,
-                                    env.clone(),
-                                    val,
-                                    &hydrated_vars,
-                                    warp_account_addr,
-                                )?)
-                            }
-                            _ => {
-                                return Err(ContractError::HydrationError {
-                                    msg: "Variable init_fn is not of type FnValue::String."
-                                        .to_string(),
-                                })
-                            }
-                        },
-                        VariableKind::Asset => match v.init_fn {
-                            FnValue::String(val) => {
-                                v.value = Some(resolve_string_value_asset(
-                                    deps,
-                                    env.clone(),
-                                    val,
+                                v.value = Some(replace_in_string(
+                                    resolve_string_value(
+                                        deps,
+                                        env.clone(),
+                                        val,
+                                        &hydrated_vars,
+                                        warp_account_addr.clone(),
+                                    )?,
                                     &hydrated_vars,
                                 )?)
                             }
@@ -171,12 +147,34 @@ pub fn hydrate_vars(
                                 })
                             }
                         },
-                        VariableKind::Json => match v.init_fn {
+                        VariableKind::Asset => match v.init_fn.clone() {
                             FnValue::String(val) => {
-                                v.value = Some(resolve_string_value_json(
-                                    deps,
-                                    env.clone(),
-                                    val,
+                                v.value = Some(replace_in_string(
+                                    resolve_string_value_asset(
+                                        deps,
+                                        env.clone(),
+                                        val,
+                                        &hydrated_vars,
+                                    )?,
+                                    &hydrated_vars,
+                                )?)
+                            }
+                            _ => {
+                                return Err(ContractError::HydrationError {
+                                    msg: "Variable init_fn is not of type FnValue::String."
+                                        .to_string(),
+                                })
+                            }
+                        },
+                        VariableKind::Json => match v.init_fn.clone() {
+                            FnValue::String(val) => {
+                                v.value = Some(replace_in_string(
+                                    resolve_string_value_json(
+                                        deps,
+                                        env.clone(),
+                                        val,
+                                        &hydrated_vars,
+                                    )?,
                                     &hydrated_vars,
                                 )?)
                             }
@@ -318,88 +316,86 @@ pub fn hydrate_msgs(msgs: String, vars: Vec<Variable>) -> Result<Vec<CosmosMsg>,
 
 fn get_replacement_in_struct(var: &Variable) -> Result<(String, String), ContractError> {
     let (name, replacement) = match var {
-        Variable::Static(v) => (v.name.clone(), {
-            match v.value.clone() {
-                None => {
-                    return Err(ContractError::HydrationError {
-                        msg: "Static msg value is none.".to_string(),
-                    });
-                }
-                Some(val) => (v.name.clone(), {
-                    match v.kind {
-                        VariableKind::Uint => format!(
-                            "\"{}\"",
-                            match v.encode {
-                                true => {
-                                    base64::encode(val)
-                                }
-                                false => val,
-                            }
-                        ),
-                        VariableKind::Int => match v.encode {
-                            true => {
-                                format!("\"{}\"", base64::encode(val))
-                            }
-                            false => val,
-                        },
-                        VariableKind::Decimal => format!(
-                            "\"{}\"",
-                            match v.encode {
-                                true => {
-                                    base64::encode(val)
-                                }
-                                false => val,
-                            }
-                        ),
-                        VariableKind::Timestamp => match v.encode {
-                            true => {
-                                format!("\"{}\"", base64::encode(val))
-                            }
-                            false => val,
-                        },
-                        VariableKind::Bool => match v.encode {
-                            true => {
-                                format!("\"{}\"", base64::encode(val))
-                            }
-                            false => val,
-                        },
-                        VariableKind::Amount => format!(
-                            "\"{}\"",
-                            match v.encode {
-                                true => {
-                                    base64::encode(val)
-                                }
-                                false => val,
-                            }
-                        ),
-                        VariableKind::String => format!(
-                            "\"{}\"",
-                            match v.encode {
-                                true => {
-                                    base64::encode(val)
-                                }
-                                false => val,
-                            }
-                        ),
-                        VariableKind::Asset => format!(
-                            "\"{}\"",
-                            match v.encode {
-                                true => {
-                                    base64::encode(val)
-                                }
-                                false => val,
-                            }
-                        ),
-                        VariableKind::Json => match v.encode {
-                            true => {
-                                format!("\"{}\"", base64::encode(val))
-                            }
-                            false => val,
-                        },
-                    }
-                }),
+        Variable::Static(v) => match v.value.clone() {
+            None => {
+                return Err(ContractError::HydrationError {
+                    msg: "Static msg value is none.".to_string(),
+                });
             }
-        }),
+            Some(val) => (v.name.clone(), {
+                match v.kind {
+                    VariableKind::Uint => format!(
+                        "\"{}\"",
+                        match v.encode {
+                            true => {
+                                base64::encode(val)
+                            }
+                            false => val,
+                        }
+                    ),
+                    VariableKind::Int => match v.encode {
+                        true => {
+                            format!("\"{}\"", base64::encode(val))
+                        }
+                        false => val,
+                    },
+                    VariableKind::Decimal => format!(
+                        "\"{}\"",
+                        match v.encode {
+                            true => {
+                                base64::encode(val)
+                            }
+                            false => val,
+                        }
+                    ),
+                    VariableKind::Timestamp => match v.encode {
+                        true => {
+                            format!("\"{}\"", base64::encode(val))
+                        }
+                        false => val,
+                    },
+                    VariableKind::Bool => match v.encode {
+                        true => {
+                            format!("\"{}\"", base64::encode(val))
+                        }
+                        false => val,
+                    },
+                    VariableKind::Amount => format!(
+                        "\"{}\"",
+                        match v.encode {
+                            true => {
+                                base64::encode(val)
+                            }
+                            false => val,
+                        }
+                    ),
+                    VariableKind::String => format!(
+                        "\"{}\"",
+                        match v.encode {
+                            true => {
+                                base64::encode(val)
+                            }
+                            false => val,
+                        }
+                    ),
+                    VariableKind::Asset => format!(
+                        "\"{}\"",
+                        match v.encode {
+                            true => {
+                                base64::encode(val)
+                            }
+                            false => val,
+                        }
+                    ),
+                    VariableKind::Json => match v.encode {
+                        true => {
+                            format!("\"{}\"", base64::encode(val))
+                        }
+                        false => val,
+                    },
+                }
+            }),
+        },
         Variable::External(v) => match v.value.clone() {
             None => {
                 return Err(ContractError::HydrationError {
@@ -567,13 +563,20 @@ fn get_replacement_in_struct(var: &Variable) -> Result<(String, String), Contrac
 
 fn get_replacement_in_string(var: &Variable) -> Result<(String, String), ContractError> {
     let (name, replacement) = match var {
-        Variable::Static(v) => (
-            v.name.clone(),
-            match v.encode {
-                true => base64::encode(v.value.clone()),
-                false => v.value.clone(),
-            },
-        ),
+        Variable::Static(v) => match v.value.clone() {
+            None => {
+                return Err(ContractError::HydrationError {
+                    msg: "Static msg value is none.".to_string(),
+                });
+            }
+            Some(val) => (
+                v.name.clone(),
+                match v.encode {
+                    true => base64::encode(val),
+                    false => val,
+                },
+            ),
+        },
         Variable::External(v) => match v.value.clone() {
             None => {
                 return Err(ContractError::HydrationError {
@@ -756,6 +759,7 @@ pub fn apply_var_fn(
     env: Env,
     vars: Vec<Variable>,
     status: JobStatus,
+    warp_account_addr: Option<String>,
 ) -> Result<String, ContractError> {
     let mut res = vec![];
     for var in vars.clone() {
@@ -778,8 +782,10 @@ pub fn apply_var_fn(
                                             msg: "Static Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_uint(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -787,8 +793,10 @@ pub fn apply_var_fn(
                                             msg: "Static Int function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_int(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_int(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Decimal(nv) => {
                                     if v.kind != VariableKind::Decimal {
@@ -796,9 +804,10 @@ pub fn apply_var_fn(
                                             msg: "Static Decimal function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value =
+                                    v.value = Some(
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string();
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -806,8 +815,10 @@ pub fn apply_var_fn(
                                             msg: "Static Timestamp function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_int(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_int(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::BlockHeight(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -816,8 +827,10 @@ pub fn apply_var_fn(
                                                 .to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_int(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_int(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Bool(val) => {
                                     if v.kind != VariableKind::Bool {
@@ -825,8 +838,27 @@ pub fn apply_var_fn(
                                             msg: "Static Bool function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_ref_bool(deps, env.clone(), val, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_ref_bool(deps, env.clone(), val, &vars)?
+                                            .to_string(),
+                                    );
+                                }
+                                FnValue::String(val) => {
+                                    if v.kind != VariableKind::String {
+                                        return Err(ContractError::FunctionError {
+                                            msg: "Static String function mismatch.".to_string(),
+                                        });
+                                    }
+                                    v.value = Some(
+                                        resolve_string_value(
+                                            deps,
+                                            env.clone(),
+                                            val,
+                                            &vars,
+                                            warp_account_addr.clone(),
+                                        )?
+                                        .to_string(),
+                                    );
                                 }
                             },
                         },
@@ -839,8 +871,10 @@ pub fn apply_var_fn(
                                             msg: "Static Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_uint(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_uint(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Int(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -848,8 +882,10 @@ pub fn apply_var_fn(
                                             msg: "Static Int function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_int(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_int(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Decimal(nv) => {
                                     if v.kind != VariableKind::Decimal {
@@ -857,9 +893,10 @@ pub fn apply_var_fn(
                                             msg: "Static Uint function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value =
+                                    v.value = Some(
                                         resolve_num_value_decimal(deps, env.clone(), nv, &vars)?
-                                            .to_string()
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Timestamp(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -867,8 +904,10 @@ pub fn apply_var_fn(
                                             msg: "Static Timestamp function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_int(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_int(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::BlockHeight(nv) => {
                                     if v.kind != VariableKind::Int {
@@ -877,8 +916,10 @@ pub fn apply_var_fn(
                                                 .to_string(),
                                         });
                                     }
-                                    v.value = resolve_num_value_int(deps, env.clone(), nv, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_num_value_int(deps, env.clone(), nv, &vars)?
+                                            .to_string(),
+                                    );
                                 }
                                 FnValue::Bool(val) => {
                                     if v.kind != VariableKind::Bool {
@@ -886,8 +927,27 @@ pub fn apply_var_fn(
                                             msg: "Static Bool function mismatch.".to_string(),
                                         });
                                     }
-                                    v.value = resolve_ref_bool(deps, env.clone(), val, &vars)?
-                                        .to_string();
+                                    v.value = Some(
+                                        resolve_ref_bool(deps, env.clone(), val, &vars)?
+                                            .to_string(),
+                                    );
+                                }
+                                FnValue::String(val) => {
+                                    if v.kind != VariableKind::String {
+                                        return Err(ContractError::FunctionError {
+                                            msg: "Static String function mismatch.".to_string(),
+                                        });
+                                    }
+                                    v.value = Some(
+                                        resolve_string_value(
+                                            deps,
+                                            env.clone(),
+                                            val,
+                                            &vars,
+                                            warp_account_addr.clone(),
+                                        )?
+                                        .to_string(),
+                                    );
                                 }
                             },
                         },
@@ -980,6 +1040,23 @@ pub fn apply_var_fn(
                                             .to_string(),
                                     )
                                 }
+                                FnValue::String(val) => {
+                                    if v.kind != VariableKind::String {
+                                        return Err(ContractError::FunctionError {
+                                            msg: "External String function mismatch.".to_string(),
+                                        });
+                                    }
+                                    v.value = Some(
+                                        resolve_string_value(
+                                            deps,
+                                            env.clone(),
+                                            val,
+                                            &vars,
+                                            warp_account_addr.clone(),
+                                        )?
+                                        .to_string(),
+                                    )
+                                }
                             },
                         },
                         JobStatus::Failed => match update_fn.on_error {
@@ -1051,6 +1128,23 @@ pub fn apply_var_fn(
                                     v.value = Some(
                                         resolve_ref_bool(deps, env.clone(), val, &vars)?
                                             .to_string(),
+                                    )
+                                }
+                                FnValue::String(val) => {
+                                    if v.kind != VariableKind::String {
+                                        return Err(ContractError::FunctionError {
+                                            msg: "External String function mismatch.".to_string(),
+                                        });
+                                    }
+                                    v.value = Some(
+                                        resolve_string_value(
+                                            deps,
+                                            env.clone(),
+                                            val,
+                                            &vars,
+                                            warp_account_addr.clone(),
+                                        )?
+                                        .to_string(),
                                     )
                                 }
                             },
@@ -1143,6 +1237,23 @@ pub fn apply_var_fn(
                                             .to_string(),
                                     )
                                 }
+                                FnValue::String(val) => {
+                                    if v.kind != VariableKind::String {
+                                        return Err(ContractError::FunctionError {
+                                            msg: "Query String function mismatch.".to_string(),
+                                        });
+                                    }
+                                    v.value = Some(
+                                        resolve_string_value(
+                                            deps,
+                                            env.clone(),
+                                            val,
+                                            &vars,
+                                            warp_account_addr.clone(),
+                                        )?
+                                        .to_string(),
+                                    )
+                                }
                             },
                         },
                         JobStatus::Failed => match update_fn.on_error {
@@ -1212,6 +1323,23 @@ pub fn apply_var_fn(
                                     v.value = Some(
                                         resolve_ref_bool(deps, env.clone(), val, &vars)?
                                             .to_string(),
+                                    )
+                                }
+                                FnValue::String(val) => {
+                                    if v.kind != VariableKind::String {
+                                        return Err(ContractError::FunctionError {
+                                            msg: "Query String function mismatch.".to_string(),
+                                        });
+                                    }
+                                    v.value = Some(
+                                        resolve_string_value(
+                                            deps,
+                                            env.clone(),
+                                            val,
+                                            &vars,
+                                            warp_account_addr.clone(),
+                                        )?
+                                        .to_string(),
                                     )
                                 }
                             },
@@ -1330,45 +1458,52 @@ fn get_var_name(var: &Variable) -> String {
 pub fn vars_valid(vars: &Vec<Variable>) -> bool {
     for var in vars {
         match var {
-            Variable::Static(v) => match v.kind {
-                VariableKind::String => {}
-                VariableKind::Uint => {
-                    if Uint256::from_str(&v.value).is_err() {
-                        return false;
+            Variable::Static(v) => {
+                if v.reinitialize && v.update_fn.is_some() {
+                    return false;
+                }
+                if let Some(val) = v.value.clone() {
+                    match v.kind {
+                        VariableKind::String => {}
+                        VariableKind::Uint => {
+                            if Uint256::from_str(&val).is_err() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Int => {
+                            if i128::from_str(&val).is_err() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Decimal => {
+                            if Decimal256::from_str(&val).is_err() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Timestamp => {
+                            if i128::from_str(&val).is_err() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Bool => {
+                            if bool::from_str(&val).is_err() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Amount => {
+                            if Uint128::from_str(&val).is_err() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Asset => {
+                            if val.is_empty() {
+                                return false;
+                            }
+                        }
+                        VariableKind::Json => {}
                     }
                 }
-                VariableKind::Int => {
-                    if i128::from_str(&v.value).is_err() {
-                        return false;
-                    }
-                }
-                VariableKind::Decimal => {
-                    if Decimal256::from_str(&v.value).is_err() {
-                        return false;
-                    }
-                }
-                VariableKind::Timestamp => {
-                    if i128::from_str(&v.value).is_err() {
-                        return false;
-                    }
-                }
-                VariableKind::Bool => {
-                    if bool::from_str(&v.value).is_err() {
-                        return false;
-                    }
-                }
-                VariableKind::Amount => {
-                    if Uint128::from_str(&v.value).is_err() {
-                        return false;
-                    }
-                }
-                VariableKind::Asset => {
-                    if v.value.is_empty() {
-                        return false;
-                    }
-                }
-                VariableKind::Json => {}
-            },
+            }
             Variable::External(v) => {
                 if v.reinitialize && v.update_fn.is_some() {
                     return false;

--- a/packages/resolver/src/condition.rs
+++ b/packages/resolver/src/condition.rs
@@ -36,7 +36,6 @@ pub enum Value<T> {
     Ref(String),
 }
 
-
 #[cw_serde]
 pub enum StringValue<String> {
     Simple(String),

--- a/packages/resolver/src/condition.rs
+++ b/packages/resolver/src/condition.rs
@@ -31,14 +31,8 @@ pub struct BlockExpr {
 }
 
 #[cw_serde]
-pub enum Value<T> {
+pub enum StringValue<T> {
     Simple(T),
-    Ref(String),
-}
-
-#[cw_serde]
-pub enum StringValue<String> {
-    Simple(String),
     Ref(String),
     Env(StringEnvValue),
 }
@@ -102,7 +96,7 @@ pub enum IntFnOp {
 
 #[cw_serde]
 pub enum Expr {
-    String(GenExpr<Value<String>, StringOp>),
+    String(GenExpr<StringValue<String>, StringOp>),
     Uint(GenExpr<NumValue<Uint256, NumExprOp, IntFnOp>, NumOp>),
     Int(GenExpr<NumValue<i128, NumExprOp, IntFnOp>, NumOp>),
     Decimal(GenExpr<NumValue<Decimal256, NumExprOp, DecimalFnOp>, NumOp>),

--- a/packages/resolver/src/condition.rs
+++ b/packages/resolver/src/condition.rs
@@ -36,6 +36,19 @@ pub enum Value<T> {
     Ref(String),
 }
 
+
+#[cw_serde]
+pub enum StringValue<String> {
+    Simple(String),
+    Ref(String),
+    Env(StringEnvValue),
+}
+
+#[cw_serde]
+pub enum StringEnvValue {
+    WarpAccountAddr,
+}
+
 #[cw_serde]
 pub enum NumValue<T, ExprOp, FnOp> {
     Simple(T),

--- a/packages/resolver/src/lib.rs
+++ b/packages/resolver/src/lib.rs
@@ -52,6 +52,7 @@ pub struct ExecuteHydrateMsgsMsg {
 pub struct ExecuteHydrateVarsMsg {
     pub vars: String,
     pub external_inputs: Option<Vec<ExternalInput>>,
+    pub warp_account_addr: Option<String>,
 }
 
 #[cw_serde]
@@ -92,6 +93,7 @@ pub struct QueryHydrateMsgsMsg {
 pub struct QueryHydrateVarsMsg {
     pub vars: String,
     pub external_inputs: Option<Vec<ExternalInput>>,
+    pub warp_account_addr: Option<String>,
 }
 
 #[cw_serde]

--- a/packages/resolver/src/lib.rs
+++ b/packages/resolver/src/lib.rs
@@ -59,6 +59,7 @@ pub struct ExecuteHydrateVarsMsg {
 pub struct ExecuteResolveConditionMsg {
     pub condition: String,
     pub vars: String,
+    pub warp_account_addr: Option<String>,
 }
 
 #[cw_serde]
@@ -101,6 +102,7 @@ pub struct QueryHydrateVarsMsg {
 pub struct QueryResolveConditionMsg {
     pub condition: String,
     pub vars: String,
+    pub warp_account_addr: Option<String>,
 }
 
 #[cw_serde]

--- a/packages/resolver/src/lib.rs
+++ b/packages/resolver/src/lib.rs
@@ -65,6 +65,7 @@ pub struct ExecuteResolveConditionMsg {
 pub struct ExecuteApplyVarFnMsg {
     pub vars: String,
     pub status: JobStatus,
+    pub warp_account_addr: Option<String>,
 }
 
 #[cw_serde]
@@ -106,6 +107,7 @@ pub struct QueryResolveConditionMsg {
 pub struct QueryApplyVarFnMsg {
     pub vars: String,
     pub status: JobStatus,
+    pub warp_account_addr: Option<String>,
 }
 
 #[cw_serde]

--- a/packages/resolver/src/variable.rs
+++ b/packages/resolver/src/variable.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Decimal256, QueryRequest, Uint256};
 
+use crate::condition::StringValue;
+
 use super::condition::{DecimalFnOp, IntFnOp, NumExprOp, NumValue};
 
 #[cw_serde]
@@ -68,19 +70,20 @@ pub enum FnOp {
 }
 
 #[cw_serde]
-pub enum UpdateFnValue {
+pub enum FnValue {
     Uint(NumValue<Uint256, NumExprOp, IntFnOp>),
     Int(NumValue<i128, NumExprOp, IntFnOp>),
     Decimal(NumValue<Decimal256, NumExprOp, DecimalFnOp>),
     Timestamp(NumValue<i128, NumExprOp, IntFnOp>),
     BlockHeight(NumValue<i128, NumExprOp, IntFnOp>),
     Bool(String), //ref
+    String(StringValue<String>),
 }
 
 #[cw_serde]
 pub struct UpdateFn {
-    pub on_success: Option<UpdateFnValue>,
-    pub on_error: Option<UpdateFnValue>,
+    pub on_success: Option<FnValue>,
+    pub on_error: Option<FnValue>,
 }
 
 // Variable is specified as a reference value (string) in form of $warp.variable.{name}
@@ -97,7 +100,9 @@ pub struct StaticVariable {
     pub kind: VariableKind,
     pub name: String,
     pub encode: bool,
-    pub value: String,
+    pub init_fn: FnValue,
+    pub reinitialize: bool,
+    pub value: Option<String>, //none if uninitialized
     pub update_fn: Option<UpdateFn>,
 }
 


### PR DESCRIPTION
Part of #63 

1. Introduce string env var `WarpAccountAddr` to `StringValue`.
2. Add `init_fn` to static var, so we can use expression to init it, so we can do this  `init_fn: FnValue::String(StringValue::Env(StringEnvValue::WarpAccountAddr))`, without knowing the warp account address at job creation time, and the account will be created atomically with the job and hydrate the var on the fly.