### PR TITLE
[Feature] Account flow improvements

### DIFF
--- a/contracts/warp-account/src/contract.rs
+++ b/contracts/warp-account/src/contract.rs
@@ -29,22 +29,12 @@ pub fn instantiate(
         },
     )?;
 
-    let mut fund_msgs_vec: Vec<CosmosMsg> = vec![];
-
-    if !info.funds.is_empty() {
-        fund_msgs_vec.push(CosmosMsg::Bank(BankMsg::Send {
-            to_address: env.contract.address.to_string(),
-            amount: info.funds.clone(),
-        }))
-    }
-
     Ok(Response::new()
         .add_attribute("action", "instantiate")
         .add_attribute("contract_addr", env.contract.address)
         .add_attribute("owner", msg.owner)
         .add_attribute("funds", serde_json_wasm::to_string(&info.funds)?)
         .add_attribute("cw_funds", serde_json_wasm::to_string(&msg.funds)?)
-        .add_messages(fund_msgs_vec)
         .add_messages(msg.msgs.unwrap_or(vec![])))
 }
 

--- a/contracts/warp-account/src/contract.rs
+++ b/contracts/warp-account/src/contract.rs
@@ -35,7 +35,7 @@ pub fn instantiate(
         .add_attribute("owner", msg.owner)
         .add_attribute("funds", serde_json_wasm::to_string(&info.funds)?)
         .add_attribute("cw_funds", serde_json_wasm::to_string(&msg.funds)?)
-        .add_messages(msg.msgs.unwrap_or(vec![])))
+        .add_attribute("account_msgs", serde_json_wasm::to_string(&msg.msgs)?))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/warp-account/src/tests.rs
+++ b/contracts/warp-account/src/tests.rs
@@ -20,6 +20,7 @@ fn test_execute_controller() {
         InstantiateMsg {
             owner: "vlad".to_string(),
             funds: None,
+            msgs: None,
         },
     );
 
@@ -142,6 +143,7 @@ fn test_execute_owner() {
         InstantiateMsg {
             owner: "vlad".to_string(),
             funds: None,
+            msgs: None,
         },
     );
 
@@ -266,6 +268,7 @@ fn test_execute_unauth() {
         InstantiateMsg {
             owner: "vlad".to_string(),
             funds: None,
+            msgs: None,
         },
     );
 

--- a/contracts/warp-controller/src/contract.rs
+++ b/contracts/warp-controller/src/contract.rs
@@ -242,6 +242,16 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                     .value,
             )?;
 
+            let account_msgs: Option<Vec<CosmosMsg>> = serde_json_wasm::from_str(
+                &event
+                    .attributes
+                    .iter()
+                    .cloned()
+                    .find(|attr| attr.key == "account_msgs")
+                    .ok_or_else(|| StdError::generic_err("cannot find `account_msgs` attribute"))?
+                    .value,
+            )?;
+
             let cw_funds_vec = match cw_funds {
                 None => {
                     vec![]
@@ -277,6 +287,12 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                         funds: vec![],
                     },
                 }))
+            }
+
+            if let Some(msgs) = account_msgs {
+                for msg in msgs {
+                    msgs_vec.push(msg);
+                }
             }
 
             if ACCOUNTS().has(deps.storage, deps.api.addr_validate(&owner)?) {

--- a/contracts/warp-controller/src/execute/account.rs
+++ b/contracts/warp-controller/src/execute/account.rs
@@ -87,6 +87,7 @@ pub fn create_account(
             msg: to_binary(&account::InstantiateMsg {
                 owner: info.sender.to_string(),
                 funds: data.funds,
+                msgs: data.msgs,
             })?,
             funds: info.funds,
             label: info.sender.to_string(),

--- a/contracts/warp-controller/src/execute/job.rs
+++ b/contracts/warp-controller/src/execute/job.rs
@@ -113,6 +113,16 @@ pub fn create_job(
         },
     ];
 
+    let mut account_msgs: Vec<WasmMsg> = vec![];
+
+    if let Some(msgs) = data.account_msgs {
+        account_msgs = vec![WasmMsg::Execute {
+            contract_addr: account.account.to_string(),
+            msg: to_binary(&account::ExecuteMsg::Generic(GenericMsg { msgs }))?,
+            funds: vec![],
+        }];
+    }
+
     Ok(Response::new()
         .add_messages(reward_send_msgs)
         .add_attribute("action", "create_job")
@@ -124,7 +134,8 @@ pub fn create_job(
         .add_attribute("job_msgs", serde_json_wasm::to_string(&job.msgs)?)
         .add_attribute("job_reward", job.reward)
         .add_attribute("job_creation_fee", fee)
-        .add_attribute("job_last_updated_time", job.last_update_time))
+        .add_attribute("job_last_updated_time", job.last_update_time)
+        .add_messages(account_msgs))
 }
 
 pub fn delete_job(

--- a/packages/account/src/lib.rs
+++ b/packages/account/src/lib.rs
@@ -13,6 +13,7 @@ pub struct Config {
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
+    pub msgs: Option<Vec<CosmosMsg>>,
     pub funds: Option<Vec<Fund>>,
 }
 

--- a/packages/controller/src/account.rs
+++ b/packages/controller/src/account.rs
@@ -1,9 +1,10 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::{Addr, CosmosMsg, Uint128};
 
 #[cw_serde]
 pub struct CreateAccountMsg {
     pub funds: Option<Vec<Fund>>,
+    pub msgs: Option<Vec<CosmosMsg>>,
 }
 
 #[cw_serde]

--- a/packages/controller/src/job.rs
+++ b/packages/controller/src/job.rs
@@ -1,6 +1,6 @@
 use crate::account::AssetInfo;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Uint128, Uint64};
+use cosmwasm_std::{Addr, CosmosMsg, Uint128, Uint64};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
@@ -66,6 +66,7 @@ pub struct CreateJobMsg {
     pub requeue_on_evict: bool,
     pub reward: Uint128,
     pub assets_to_withdraw: Option<Vec<AssetInfo>>,
+    pub account_msgs: Option<Vec<CosmosMsg>>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
Adds following capabilities to create_account instantiate:
- cw20/cw721 funding logic provided by info.funds
- optional msgs array in CreateAccountMsg to be executed post funding 
- create_job accepts a account_msgs arg, which is just a generic msg passthrough to account
  - useful for atomic use case when account addr is unknown